### PR TITLE
Add texture changes (optimizations)

### DIFF
--- a/src/rajawali/materials/TextureManager.java
+++ b/src/rajawali/materials/TextureManager.java
@@ -38,6 +38,10 @@ public class TextureManager {
 	}
 	
 	public TextureInfo addTexture(Bitmap texture) {
+		return this.addTexture(texture, true, true);	
+	}
+
+	public TextureInfo addTexture(Bitmap texture, boolean mipmap, boolean recycle) {
 		if(mTextureInfoList.size() > mMaxTextures)
 			throw new RuntimeException("Max number of textures used");
 
@@ -52,16 +56,21 @@ public class TextureManager {
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);
 		
         GLUtils.texImage2D(GLES20.GL_TEXTURE_2D, 0, bitmapFormat, texture, 0);
-        GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR_MIPMAP_LINEAR);
+        if(mipmap)
+        	GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR_MIPMAP_LINEAR);
+        else
+        	GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
         GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_REPEAT);
         GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_REPEAT);
-        GLES20.glGenerateMipmap(GLES20.GL_TEXTURE_2D);
+        if(mipmap)
+        	GLES20.glGenerateMipmap(GLES20.GL_TEXTURE_2D);
         
         TextureInfo textureInfo = new TextureInfo(textureId, textureSlot);
         mTextureInfoList.add(textureInfo);
 
-        texture.recycle();
+        if(recycle)
+        	texture.recycle();
         return textureInfo;
 	}
 	


### PR DESCRIPTION
*Mipmapping: It is not always needed to do mipmapping so I made it possible to disable mipmap generation.
*Recycling: For live wallpapers it is a good idea to store the loaded texture outside of the opengl context since it gets deleted every time a fly lands on the phone, if we store the texture outside the opengl context then we don't need to reload it from disk all the time thus saving time. So when doing this we need to not recycle the texture after loading it since we will need to load it again in a little while.
