### PR TITLE
CubeMap per texture instead of per material

### DIFF
--- a/src/rajawali/materials/AMaterial.java
+++ b/src/rajawali/materials/AMaterial.java
@@ -196,7 +196,7 @@ public abstract class AMaterial {
 
 		for (int i = 0; i < num; i++) {
 			TextureInfo ti = mTextureInfoList.get(i);
-			int type = usesCubeMap ? GLES20.GL_TEXTURE_CUBE_MAP
+			int type = ti.isCubeMap() ? GLES20.GL_TEXTURE_CUBE_MAP
 					: GLES20.GL_TEXTURE_2D;
 			GLES20.glActiveTexture(GLES20.GL_TEXTURE0 + i);
 			GLES20.glBindTexture(type, ti.getTextureId());

--- a/src/rajawali/materials/TextureInfo.java
+++ b/src/rajawali/materials/TextureInfo.java
@@ -38,6 +38,8 @@ public class TextureInfo {
 	protected boolean mMipmap;
 	protected Config mBitmapConfig;
 	
+	protected boolean isCubeMap = false;
+	
 	/**
 	 * OpenGL bitmap format
 	 */
@@ -74,6 +76,14 @@ public class TextureInfo {
 
 	public int getUniformHandle() {
 		return mUniformHandle;
+	}
+	
+	public boolean isCubeMap() {
+		return isCubeMap;
+	}
+	
+	public void setIsCubeMap(boolean cube) {
+		isCubeMap = cube;
 	}
 
 	public String toString() {

--- a/src/rajawali/materials/TextureManager.java
+++ b/src/rajawali/materials/TextureManager.java
@@ -154,6 +154,8 @@ public class TextureManager {
 		textureInfo.setBitmapConfig(textures[0].getConfig());
 		textureInfo.setMipmap(mipmap);
 		
+		textureInfo.setIsCubeMap(true);
+		
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_CUBE_MAP, textureId);
 		if(mipmap)
 			GLES20.glTexParameterf(GLES20.GL_TEXTURE_CUBE_MAP, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR_MIPMAP_LINEAR);


### PR DESCRIPTION
...ld use for example diffuse as well as a cubemap since all the textures would be mapped as a cubemap.
