### PR TITLE
Set light direction with setLookAt() method

### DIFF
--- a/src/rajawali/lights/DirectionalLight.java
+++ b/src/rajawali/lights/DirectionalLight.java
@@ -1,24 +1,39 @@
 package rajawali.lights;
 
+import rajawali.math.Number3D;
 
 public class DirectionalLight extends ALight {
 	protected float[] mDirection = new float[3];
-	
+
 	public DirectionalLight() {
-		super(DIRECTIONAL_LIGHT);
-		setDirection(0, -1.0f, 1.0f);
+		this(0, -1.0f, 1.0f);
 	}
-	
+
 	public DirectionalLight(float xDir, float yDir, float zDir) {
 		super(DIRECTIONAL_LIGHT);
 		setDirection(xDir, yDir, zDir);
 	}
-	
+
 	public void setDirection(float x, float y, float z) {
-		mDirection[0] = x; mDirection[1] = y; mDirection[2] = z;
+		mDirection[0] = x;
+		mDirection[1] = y;
+		mDirection[2] = z;
 	}
-	
+
+	public void setDirection(Number3D dir) {
+		setDirection(dir.x, dir.y, dir.z);
+	}
+
 	public float[] getDirection() {
 		return mDirection;
+	}
+
+	public void setLookAt(float x, float y, float z) {
+		super.setLookAt(x, y, z);
+		Number3D dir = new Number3D(x, y, z);
+		dir.subtract(mPosition);
+		dir.x = -dir.x;
+		dir.normalize();
+		setDirection(dir);
 	}
 }


### PR DESCRIPTION
While tinkering with DirectionalLight objects, my first intuition was to use setLookAt() to set the direction. However, I was sad that it didn't work. Here is a naive implementation for review.

I would love to know what the heck is going on with the X-axis. For some reason I had to negate it in order to get it to work the way I'd expect. I noticed that ATransformable3D.setLookAt() also negates the X-coordinate. Is this related?
