### PR TITLE
Set missing camera position for particles

### DIFF
--- a/src/rajawali/primitives/Particle.java
+++ b/src/rajawali/primitives/Particle.java
@@ -62,6 +62,7 @@ public class Particle extends BaseObject3D {
 			throw new RuntimeException("You need to set a particle material first.");
 		}
 		mParticleShader.setCamera(camera);
+		mParticleShader.setCameraPosition(camera.getPosition());
 		mParticleShader.setPointSize(mPointSize);
 	}
 }


### PR DESCRIPTION
Particles are freakishly larger than the screen when the camera
is not set. Setting the camera in the primitive, rather than
expecting the user to do it / figure it out, improves the out-of-box
experience.

I'm also eye-balling some other things that could possibly be improved, such as the default point size (which is too small to be visible).
