### PR TITLE
Fixes #147

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -228,7 +228,10 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 		GLES20.glFrontFace(GLES20.GL_CCW);
 		GLES20.glCullFace(GLES20.GL_BACK);
 
-		if (!mSceneInitialized) {
+		if (mChildren == null)
+			mChildren = new Stack<BaseObject3D>();
+		
+		if (!mSceneInitialized) {			
 			mTextureManager = new TextureManager();
 			initScene();
 		}


### PR DESCRIPTION
Fixes #140 mChildren would sometimes show null. I believe onDestroy scene is the culprit as it sets mChildren to null. As I do not know if that is necessary or not in onDestroy, I have created a work around that should resolve the problem.
