### PR TITLE
Fixes #140 Removed line that nulled mChildren causing issues on certain devices.

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -270,7 +270,6 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 			child.destroy();
 		}
 		mChildren.clear();
-		mChildren = null;
 	}
 	
 	public void startRendering() {


### PR DESCRIPTION
As suggested, removed line setting mChildren to null as certain devices or projects seem to continue trying to use the renderer after it has been destroyed.
