### PR TITLE
Make particles easier to extend

### DIFF
--- a/src/rajawali/materials/AParticleMaterial.java
+++ b/src/rajawali/materials/AParticleMaterial.java
@@ -1,0 +1,26 @@
+package rajawali.materials;
+
+import rajawali.math.Number3D;
+
+public abstract class AParticleMaterial extends AMaterial {
+
+	public AParticleMaterial(String vertexShader, String fragmentShader,
+			boolean vertexAnimationEnabled) {
+		super(vertexShader, fragmentShader, vertexAnimationEnabled);
+	}
+
+	public AParticleMaterial(String vertexShader, String fragmentShader,
+			int parameters) {
+		super(vertexShader, fragmentShader, parameters);
+	}
+
+	public AParticleMaterial(int parameters) {
+		super(parameters);
+	}
+
+	public void setPointSize(float pointSize) {
+	}
+
+	public void setCameraPosition(Number3D cameraPos) {
+	}
+}

--- a/src/rajawali/materials/ParticleMaterial.java
+++ b/src/rajawali/materials/ParticleMaterial.java
@@ -6,7 +6,7 @@ import rajawali.math.Number3D;
 import android.opengl.GLES20;
 
 
-public class ParticleMaterial extends AMaterial {
+public class ParticleMaterial extends AParticleMaterial {
 	protected static final String mVShader = 
 		"precision mediump float;\n" +
 		"uniform mat4 uMVPMatrix;\n" +
@@ -97,9 +97,13 @@ public class ParticleMaterial extends AMaterial {
 	public ParticleMaterial() {
 		this(false);
 	}
-	
+
 	public ParticleMaterial(boolean isAnimated) {
-		super(mVShader, mFShader, NONE);
+		this(mVShader, mFShader, isAnimated);
+	}
+
+	public ParticleMaterial(String vertexShader, String fragmentShader, boolean isAnimated) {
+		super(vertexShader, fragmentShader, NONE);
 		mDistanceAtt = new float[] {1, 1, 1};
 		mFriction = new float[3];
 		mCamPos = new float[3];

--- a/src/rajawali/primitives/Particle.java
+++ b/src/rajawali/primitives/Particle.java
@@ -2,15 +2,13 @@ package rajawali.primitives;
 
 import rajawali.BaseObject3D;
 import rajawali.Camera;
-import rajawali.materials.AMaterial;
-import rajawali.materials.ParticleMaterial;
+import rajawali.materials.AParticleMaterial;
 import rajawali.util.RajLog;
 import android.opengl.GLES20;
 
-
 public class Particle extends BaseObject3D {
 	protected float mPointSize = 10.0f;
-	protected ParticleMaterial mParticleShader;
+	protected AParticleMaterial mParticleShader;
 	
 	public Particle() {
 		super();
@@ -48,11 +46,16 @@ public class Particle extends BaseObject3D {
 		setData(vertices, normals, textureCoords, colors, indices);
 	}
 	
-	public void setMaterial(AMaterial material, boolean copyTextures) {
-		super.setMaterial(material, copyTextures);
-		mParticleShader = (ParticleMaterial)material;
+	public void setMaterial(AParticleMaterial material) {
+		super.setMaterial(material);
+		mParticleShader = material;
 	}
 	
+	public void setMaterial(AParticleMaterial material, boolean copyTextures) {
+		super.setMaterial(material, copyTextures);
+		mParticleShader = material;
+	}
+
 	@Override
 	protected void setShaderParams(Camera camera) {
 		super.setShaderParams(camera);


### PR DESCRIPTION
In the process of trying to make light affect my particle, I was hitting some walls trying to extend ParticleMaterial. These are additions and changes I made to Rajawali to make my life easier. Little thought was put into it, so please review it.

Main changes:
- AParticleMaterial is a new interface that the Particle primitive will rely on. Previously, it was permitting only ParticleMaterial objects.
- ParticleMaterial had some more wrappers added, including a constructor that allows a sub-class to specify its own shaders (rather than the ones hard-coded in ParticleMaterial).
