### PR TITLE
Remove "final" keyword from Number3D class

### DIFF
--- a/src/rajawali/math/Number3D.java
+++ b/src/rajawali/math/Number3D.java
@@ -8,7 +8,7 @@ import android.util.FloatMath;
  * @author dennis.ippel
  *
  */
-public final class Number3D {
+public class Number3D {
 	public float x;
 	public float y;
 	public float z;


### PR DESCRIPTION
Now it can be extended by a subclass.

My current project has pathing nodes that are essentially just coordinates (Number3D) with an extra attribute and some new methods. Extending Number3D is the simplest and least verbose way to get what I need.

It is my understanding that the "final" keyword can improve performance, but I cannot feel a difference. (Does a Rajawali benchmark exist for objectively measuring this type of thing?) I think the added utility makes it an acceptable trade-off.
