### PR TITLE
Add BaseObject3D.cloneTo() helper method

### DIFF
--- a/src/rajawali/BaseObject3D.java
+++ b/src/rajawali/BaseObject3D.java
@@ -601,12 +601,16 @@ public class BaseObject3D extends ATransformable3D implements Comparable<BaseObj
 		return ser;
 	}
 
-	public BaseObject3D clone(boolean copyMaterial) {
-		BaseObject3D clone = new BaseObject3D();
+	protected void cloneTo(BaseObject3D clone, boolean copyMaterial) {
 		clone.getGeometry().copyFromGeometry3D(mGeometry);
 		clone.isContainer(mIsContainerOnly);
 		if(copyMaterial) clone.setMaterial(mMaterial, false);
 		clone.mElementsBufferType = mGeometry.areOnlyShortBuffersSupported() ? GLES20.GL_UNSIGNED_SHORT : GLES20.GL_UNSIGNED_INT;
+	}
+
+	public BaseObject3D clone(boolean copyMaterial) {
+		BaseObject3D clone = new BaseObject3D();
+		cloneTo(clone, copyMaterial);
 		return clone;
 	}
 	


### PR DESCRIPTION
Intended to ease subclassing:

``` Java
public MyClass extends BaseObject3D {
    public MyClass() {
        super();
        // ... subclass-specific code ...
    }
    public MyClass clone() {
        MyClass clone = new MyClass();
        super.cloneTo(clone, true);
        // ... subclass-specific code ...
        return clone;
    }
}
```

If I am missing a better or more idiomatic way to do this, (that may not require a BaseObject3D change,) please let me know. I am still in the process of learning common Java design patterns.
