### PR TITLE
Fix negative direction in RotateAroundAnimation3D

### DIFF
--- a/src/rajawali/animation/RotateAroundAnimation3D.java
+++ b/src/rajawali/animation/RotateAroundAnimation3D.java
@@ -25,7 +25,7 @@ public class RotateAroundAnimation3D extends Animation3D {
 	
 	@Override
 	protected void applyTransformation(float interpolatedTime) {
-		float radians = mDirection * 360f * interpolatedTime * PI_DIV_180;
+		float radians = 360f * interpolatedTime * PI_DIV_180;
 		
 		float cosVal = FloatMath.cos(radians) * mDistance;
 		float sinVal = FloatMath.sin(radians) * mDistance;


### PR DESCRIPTION
Animation3D already takes a negative direction into account. Applying
it again in RotateAroundAnimation3D effectively cancels it out.

Fixes #167
