### PR TITLE
Prevent crash when picker material is null

### DIFF
--- a/src/rajawali/util/ObjectColorPicker.java
+++ b/src/rajawali/util/ObjectColorPicker.java
@@ -41,7 +41,9 @@ public class ObjectColorPicker implements IObjectPicker {
 		int[] frameBuffers = new int[1];
 		GLES20.glGenFramebuffers(1, frameBuffers, 0);
 		mFrameBufferHandle = frameBuffers[0];
-		mPickerMaterial.reload();
+		if (mPickerMaterial != null) {
+			mPickerMaterial.reload();
+		}
 	}
 	
 	public void setOnObjectPickedListener(OnObjectPickedListener objectPickedListener) {


### PR DESCRIPTION
This fixes a crash in my live wallpaper.

Steps to reproduce on Nexus 7:
1. Press power button to turn display off
2. Press power button to turn display on
3. Touch the wallpaper

The wallpaper crashes with a NullPointerException on mPickerMaterial.reload().
