### PR TITLE
Preserve alpha channel in light and fog math

### DIFF
--- a/src/rajawali/materials/AAdvancedMaterial.java
+++ b/src/rajawali/materials/AAdvancedMaterial.java
@@ -46,7 +46,7 @@ public abstract class AAdvancedMaterial extends AMaterial {
 			"#endif\n\n";
 	public static final String M_FOG_FRAGMENT_COLOR =
 			"\n#ifdef FOG_ENABLED\n" +
-			"	gl_FragColor = mix(gl_FragColor,vec4(uFogColor,1.0),fogDensity);\n" +
+			"	gl_FragColor.rgb = mix(gl_FragColor.rgb, uFogColor, fogDensity);\n" +
 			"#endif\n\n";
 	
 	protected int muNormalMatrixHandle;

--- a/src/rajawali/materials/DiffuseMaterial.java
+++ b/src/rajawali/materials/DiffuseMaterial.java
@@ -79,7 +79,7 @@ public class DiffuseMaterial extends AAdvancedMaterial {
 		
 		M_FOG_FRAGMENT_CALC +
 		
-		"	gl_FragColor = uAmbientIntensity * uAmbientColor + intensity * gl_FragColor;" +
+		"	gl_FragColor.rgb = uAmbientIntensity.rgb * uAmbientColor.rgb + intensity * gl_FragColor.rgb;\n" +
 		M_FOG_FRAGMENT_COLOR +		
 		"}";
 	
@@ -118,7 +118,7 @@ public class DiffuseMaterial extends AAdvancedMaterial {
 				vc.append("vAttenuation").append(i).append(" = 1.0;\n");
 				sb.append("L = -normalize(uLightDirection").append(i).append(");\n");				
 			}
-			//sb.append("gl_FragColor += vec4(uLightColor").append(i).append(", 1.0);\n");
+			//sb.append("gl_FragColor.rgb += uLightColor").append(i).append(";\n");
 			sb.append("intensity += uLightPower").append(i).append(" * max(dot(N, L), 0.1) * vAttenuation").append(i).append(";\n");
 		}
 		


### PR DESCRIPTION
The light and fog math was munching the alpha channel from my semi-translucent texture.
