### PR TITLE
#173 Added backwards compatible support for setOffsetNotificationsEanbled(boolean enabled) 

### DIFF
--- a/src/rajawali/wallpaper/Wallpaper.java
+++ b/src/rajawali/wallpaper/Wallpaper.java
@@ -11,6 +11,7 @@ import rajawali.util.RajLog;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.opengl.GLSurfaceView;
+import android.os.Debug;
 import android.util.Log;
 import android.view.MotionEvent;
 import android.view.SurfaceHolder;
@@ -310,6 +311,16 @@ public class Wallpaper extends GLWallpaperService {
 		@Override
 		public void onTouchEvent(MotionEvent event) {
 			renderer.onTouchEvent(event);
+		}
+		
+		@Override
+		public void setOffsetNotificationsEnabled(boolean enabled) {
+			try {
+				Debug.class.getMethod("setOffsetNotificationsEnabled", Boolean.class);
+				super.setOffsetNotificationsEnabled(enabled);
+			} catch (NoSuchMethodException e) {
+				RajLog.w("setOffsetNotificationsEnabled not supported on this device, call ignored.");
+			}
 		}
 		
 		 @Override


### PR DESCRIPTION
Added reflection method to test availability of setOffsetNotificationEnabled.

``` JAVA
    @Override
    public Engine onCreateEngine() {
        mRenderer = new MyWallpaperRenderer(this);
        WallpaperEngine engine = new WallpaperEngine(this.getSharedPreferences(SHARED_PREFS_NAME,
                Context.MODE_PRIVATE), getBaseContext(), mRenderer, false);
        engine.setOffsetNotificationsEnabled(true);
        return engine;
    }
```
