### PR TITLE
Add parameter check in material constructor

### DIFF
--- a/src/rajawali/materials/AAdvancedMaterial.java
+++ b/src/rajawali/materials/AAdvancedMaterial.java
@@ -81,7 +81,8 @@ public abstract class AAdvancedMaterial extends AMaterial {
 	}
 	
 	public AAdvancedMaterial(String vertexShader, String fragmentShader, boolean isAnimated) {
-		this(vertexShader, fragmentShader, AMaterial.VERTEX_ANIMATION);
+		this(vertexShader, fragmentShader,
+				isAnimated ? AMaterial.VERTEX_ANIMATION : AMaterial.NONE);
 	}
 	
 	public AAdvancedMaterial(String vertexShader, String fragmentShader, int parameters) {


### PR DESCRIPTION
Vertex animation was being enabled when it wasn't supposed to be.
This caused the vertex shader to use undefined junk data, resulting
in geometry corruption.

Fixes #177
