### PR TITLE
Simplify color picking and fix depth problem

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -144,7 +144,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 			if(mReloadPickerInfo) pickerInfo.getPicker().reload();
 			mReloadPickerInfo = false;
 			pickerInfo.getPicker().bindFrameBuffer();
-			GLES20.glClearColor(0, 0, 0, 1);
+			GLES20.glClearColor(255, 255, 255, 255);
 		} else {
 			if (mFilters.size() == 0)
 				GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0);


### PR DESCRIPTION
Fixes #160 by adding a depth component. Implementation copied from PostProcessingRenderer. Note that `glDelete[...]buffers()` is not called. There was no pre-existing `destroy()` method and I am not sure if it is necessary.

The color matching and selection was also simplified to remove loops. The color value is now just an index for the list of registered objects.

Please review.
