### PR TITLE
erroneous conversion to radians

### DIFF
--- a/src/rajawali/math/Quaternion.java
+++ b/src/rajawali/math/Quaternion.java
@@ -588,7 +588,7 @@ public final class Quaternion {
 
             axis.normalize();
 
-            q.fromAngleAxis(MathUtil.degreesToRadians(180), axis);
+            q.fromAngleAxis(180, axis);
         }
         else
         {


### PR DESCRIPTION
`Quaternion.fromAngleAxis()` expects angle in degrees, was getting passed radians from `Quaternion.getRotationTo()`
