### PR TITLE
Added setExportDirectory() to MeshExporter

### DIFF
--- a/src/rajawali/util/MeshExporter.java
+++ b/src/rajawali/util/MeshExporter.java
@@ -59,6 +59,8 @@ public class MeshExporter {
 		File path;
 		if(mExportDir == null)
 			path = Environment.getExternalStorageDirectory();
+		else
+			path = mExportDir;
 		
 		// I don't know why the previous directory construction had to be so complex.
 		// This constructor does the exact same thing, if I'm not mistaken.


### PR DESCRIPTION
Currently, the MeshExporter class invariably exports to Environment.getExternalStorageDirectory() which can be undesirable in some cases.

These quick edits allow the user to set a custom directory to the MeshExporter object, but if the user doesn't set a custom directory then it defaults to Environment.getExternalStorageDirectory().

See the related issue https://github.com/MasDennis/Rajawali/issues/299 for more information.
