### PR TITLE
Ignore #comments and empty lines while parsing .obj and .mtl files.

### DIFF
--- a/src/rajawali/animation/RotateAnimation3D.java
+++ b/src/rajawali/animation/RotateAnimation3D.java
@@ -1,6 +1,5 @@
 package rajawali.animation;
 
-import android.util.Log;
 import rajawali.ATransformable3D;
 import rajawali.math.Number3D;
 import rajawali.math.Number3D.Axis;
@@ -56,7 +55,6 @@ public class RotateAnimation3D extends Animation3D {
 	@Override
 	protected void applyTransformation(float interpolatedTime) {
 		mRotationAngle = mRotateFrom + (interpolatedTime * mDegreesToRotate);
-		//Log.d("Rajawali", "" + mRotationAngle);
 		mQuat.fromAngleAxis(mRotationAngle, mRotationAxis);
 		mQuat.multiply(mQuatFrom);
 		mTransformable3D.setOrientation(mQuat);

--- a/src/rajawali/parser/ObjParser.java
+++ b/src/rajawali/parser/ObjParser.java
@@ -110,6 +110,9 @@ public class ObjParser extends AMeshParser {
 		
 		try {
 			while((line = buffer.readLine()) != null) {
+				// Skip comments and empty lines.
+				if(line.length() == 0 || line.charAt(0) == '#')
+					continue;
 				StringTokenizer parts = new StringTokenizer(line, " ");
 				int numTokens = parts.countTokens();
 				
@@ -353,6 +356,9 @@ public class ObjParser extends AMeshParser {
 			
 			try {
 				while((line = buffer.readLine()) != null) {
+					// Skip comments and empty lines.
+					if(line.length() == 0 || line.charAt(0) == '#')
+						continue;
 					StringTokenizer parts = new StringTokenizer(line, " ");
 					int numTokens = parts.countTokens();
 					


### PR DESCRIPTION
There is no point in creating a StringTokenizer for a comment or an empty line.
I noticed that SketchUp adds lots of comments to its .obj and .mtl files.
This update should slightly speed up parsing by ignoring comments and empty
lines at the very first opportunity.
