### PR TITLE
Fixed mVShader

### DIFF
--- a/src/rajawali/materials/GPUSkinningMaterial.java
+++ b/src/rajawali/materials/GPUSkinningMaterial.java
@@ -68,7 +68,7 @@ public class GPUSkinningMaterial extends PhongMaterial{
 			"	vTextureCoord = aTextureCoord;\n" +
 			
 			"	vEyeVec = -vec3(uMMatrix  * position);\n" +
-			"	vNormal = mat3(TransformedMatrix) * normal;\n" +
+			"	vNormal = mat3(uMMatrix) * mat3(TransformedMatrix) * normal;\n"
 			
 			"%LIGHT_CODE%" +
 			


### PR DESCRIPTION
Forgot to transform vNormal by mat3(uMMatrix), which caused lights to move with the mesh.
