### PR TITLE
Added simple alpha mapping

### DIFF
--- a/src/rajawali/materials/AMaterial.java
+++ b/src/rajawali/materials/AMaterial.java
@@ -280,6 +280,9 @@ public abstract class AMaterial {
 		case SPECULAR:
 			textureName = "uSpecularTexture";
 			break;
+		case ALPHA:
+			textureName = "uAlphaTexture";
+			break;
 		case FRAME_BUFFER:
 			textureName = "uFrameBufferTexture";
 			break;

--- a/src/rajawali/materials/SimpleAlphaMaterial.java
+++ b/src/rajawali/materials/SimpleAlphaMaterial.java
@@ -1,0 +1,30 @@
+package rajawali.materials;
+
+public class SimpleAlphaMaterial extends SimpleMaterial {
+	protected static final String mFShader = 
+		"precision mediump float;\n" +
+
+		"varying vec2 vTextureCoord;\n" +
+		"uniform sampler2D uDiffuseTexture;\n" +
+		"uniform sampler2D uAlphaTexture;\n" +
+		"varying vec4 vColor;\n" +
+
+		"void main() {\n" +
+		"#ifdef TEXTURED\n" +
+		"	gl_FragColor.rgb = texture2D(uDiffuseTexture, vTextureCoord).rgb;\n" +
+		"	gl_FragColor.a = texture2D(uAlphaTexture, vTextureCoord).r;\n" +
+		"#else\n" +
+		"	gl_FragColor = vColor;\n" +
+		"#endif\n" +
+		"}\n";
+	
+	public SimpleAlphaMaterial() {
+		super(SimpleMaterial.mVShader, mFShader);
+		setShaders();
+	}
+	
+	public SimpleAlphaMaterial(String vertexShader, String fragmentShader) {
+		super(vertexShader, fragmentShader);
+		setShaders();
+	}
+}

--- a/src/rajawali/materials/TextureManager.java
+++ b/src/rajawali/materials/TextureManager.java
@@ -73,6 +73,7 @@ public class TextureManager {
 		DIFFUSE,
 		BUMP,
 		SPECULAR,
+		ALPHA,
 		FRAME_BUFFER,
 		DEPTH_BUFFER,
 		LOOKUP,


### PR DESCRIPTION
<h3> Reason

Coding a live wallpaper to handle 4 different types of compression as well as falling back to uncompressed bitmaps was getting a bit hairy for me. ETC1 compression is the most widely available texture compression type on mobile, but it lacks support for an alpha channel. Many of the ETC1 compression tools will take an input RGBA image and will output two RGB compressed textures -- one diffuse, and one alpha map.

To support the use of ETC1 I needed to create a simple way to map alpha, and I started with extending the SimpleMaterial class in a new material class called `SimpleAlphaMaterial`.

<h3> How

`AMaterial` and `TextureManager` were changed to add the enum `ALPHA` and create a corresponding `TextureType.ALPHA`.

To use this material you must add two ETC1 textures to your material/object. One of `TextureType.DIFFUSE`, and one `TextureType.ALPHA'. Your alpha map should be white(255) for fully opaque, and black(0) for fully transparent.

``` java

mySimpleAlphaMat.addTexture(mTextureManager.addEtc1Texture(mContext.getResources().openRawResource(R.raw.my_etc1_diff), BitmapFactory.decodeResource(mContext.getResources(), R.drawable.my_fallback_img), TextureType.DIFFUSE));

mySimpleAlphaMat.addTexture(mTextureManager.addEtc1Texture(mContext.getResources().openRawResource(R.raw.my_etc1_alpha), BitmapFactory.decodeResource(mContext.getResources(), R.drawable.my_fallback_img), TextureType.ALPHA));

```

For each object that uses this material be sure to enable transparency:

`myObj.setTransparent(true)`

or enable blending:

``` java
myObj.setBlendingEnabled(true);
myObj.setBlendFunc(GLES20.GL_SRC_ALPHA, GLES20.GL_ONE_MINUS_SRC_ALPHA);
```

I plan to extend the rest of the materials this way so that any material type can fully support ETC1.
