### PR TITLE
Modified base materials to utilize uLightColor

### DIFF
--- a/src/rajawali/materials/BumpmapMaterial.java
+++ b/src/rajawali/materials/BumpmapMaterial.java
@@ -27,7 +27,7 @@ public class BumpmapMaterial extends AAdvancedMaterial {
 		    "	float intensity = 0.0;" +
 		    "	vec3 L = vec3(0.0);\n" +
 		    "%LIGHT_CODE%" +
-			" 	vec3 color = Kd * intensity * texture2D(uDiffuseTexture, vTextureCoord).rgb;" +
+			" 	vec3 color = Kd * texture2D(uDiffuseTexture, vTextureCoord).rgb;" +
 		    "	gl_FragColor = vec4(color, 1.0) + uAmbientColor * uAmbientIntensity;\n" + 
 		    M_FOG_FRAGMENT_COLOR +
 			"}";
@@ -59,7 +59,7 @@ public class BumpmapMaterial extends AAdvancedMaterial {
 				sb.append("L = -normalize(uLightDirection").append(i).append(");");				
 			}
 			sb.append("intensity += uLightPower").append(i).append(" * max(dot(bumpnormal, L), 0.1) * vAttenuation").append(i).append(";\n");
-			sb.append("Kd += uLightColor").append(i).append(";\n");
+			sb.append("Kd += uLightColor").append(i).append(" * uLightPower").append(i).append(" * max(dot(bumpnormal, L), 0.1) * vAttenuation").append(i).append(";\n");
 		}
 		
 		super.setShaders(vertexShader.replace("%LIGHT_CODE%", vc.toString()), fragmentShader.replace("%LIGHT_CODE%", sb.toString()));

--- a/src/rajawali/materials/BumpmapPhongMaterial.java
+++ b/src/rajawali/materials/BumpmapPhongMaterial.java
@@ -35,7 +35,7 @@ public class BumpmapPhongMaterial extends PhongMaterial {
 			"	bumpnormal = normalize(bumpnormal + N);" +
 			
 			"%LIGHT_CODE%" +
-			"	Kd *= intensity;\n" +		
+
 			"#ifdef TEXTURED\n" +
 		    "	vec4 diffuse  = Kd * texture2D(uDiffuseTexture, vTextureCoord);\n" +
 			"#else\n" +
@@ -75,7 +75,7 @@ public class BumpmapPhongMaterial extends PhongMaterial {
 		
 			fc.append("NdotL = max(dot(bumpnormal, L), 0.1);\n");
 			fc.append("intensity += NdotL * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n");
-			fc.append("Kd.rgb += uLightColor").append(i).append(";\n");
+			fc.append("Kd.rgb += uLightColor").append(i).append(" * NdotL * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n");
 			fc.append("Ks += pow(NdotL, uShininess) * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n");
 		}
 		

--- a/src/rajawali/materials/DiffuseMaterial.java
+++ b/src/rajawali/materials/DiffuseMaterial.java
@@ -79,7 +79,7 @@ public class DiffuseMaterial extends AAdvancedMaterial {
 
 	    "%LIGHT_CODE%" +
 		"	vec3 ambient = uAmbientIntensity.rgb * uAmbientColor.rgb;\n" +
-		"	vec3 diffuse = Kd * intensity * gl_FragColor.rgb;\n" +
+		"	vec3 diffuse = Kd * gl_FragColor.rgb;\n" +
 		"	gl_FragColor.rgb = ambient + diffuse;\n" +
 		M_FOG_FRAGMENT_COLOR +		
 		"}";
@@ -119,8 +119,8 @@ public class DiffuseMaterial extends AAdvancedMaterial {
 				vc.append("vAttenuation").append(i).append(" = 1.0;\n");
 				sb.append("L = -normalize(uLightDirection").append(i).append(");\n");				
 			}
-			sb.append("intensity += uLightPower").append(i).append(" * max(dot(N, L), 0.1) * vAttenuation").append(i).append(";\n");
-			sb.append("Kd += uLightColor").append(i).append(";\n");
+			sb.append("intensity +=  uLightPower").append(i).append(" * max(dot(N, L), 0.1) * vAttenuation").append(i).append(";\n");
+			sb.append("Kd += uLightColor").append(i).append(" * uLightPower").append(i).append(" * max(dot(N, L), 0.1) * vAttenuation").append(i).append(";\n");
 		}
 		
 		super.setShaders(vertexShader.replace("%LIGHT_CODE%", vc.toString()), fragmentShader.replace("%LIGHT_CODE%", sb.toString()));

--- a/src/rajawali/materials/PhongMaterial.java
+++ b/src/rajawali/materials/PhongMaterial.java
@@ -84,7 +84,6 @@ public class PhongMaterial extends AAdvancedMaterial {
 		"	vec3 E = normalize(vEyeVec);\n" +
 
 		"%LIGHT_CODE%" +
-		"	Kd *= intensity;\n" +		
 		"#ifdef TEXTURED\n" +
 		"	vec4 diffuse = Kd * texture2D(uDiffuseTexture, vTextureCoord);\n" +
 		"#else\n" +
@@ -174,7 +173,7 @@ public class PhongMaterial extends AAdvancedMaterial {
 			}
 			fc.append("NdotL = max(dot(N, L), 0.1);\n");
 			fc.append("intensity += NdotL * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n"); 
-			fc.append("Kd.rgb += uLightColor").append(i).append(";\n");
+			fc.append("Kd.rgb += uLightColor").append(i).append(" * NdotL * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n"); 
 			fc.append("Ks += pow(NdotL, uShininess) * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n");
 		}
 		

--- a/src/rajawali/materials/ToonMaterial.java
+++ b/src/rajawali/materials/ToonMaterial.java
@@ -37,7 +37,7 @@ public class ToonMaterial extends DiffuseMaterial {
 			"   else if(intensity > .5) color = uToonColor1;\n" +
 			"   else if(intensity > .25) color = uToonColor2;\n" +
 			"   else color = uToonColor3;\n" +
-			"	color.rgb *= Kd * intensity;\n" +	
+			"	color.rgb *= Kd;\n" +	
 			"	color += uAmbientColor * uAmbientIntensity;\n" +
 			"	gl_FragColor = color;\n" +
 			M_FOG_FRAGMENT_COLOR +	


### PR DESCRIPTION
<h3> Reason

To resolve requests: https://github.com/MasDennis/Rajawali/issues/225 https://github.com/MasDennis/Rajawali/issues/324

Rajawali has had the ability to set the light color, but the materials were not utilizing the light color.

<h3> Method

The accepted equations for calculating light and texture color are as follows:

ambient = Ka x globalAmbient
diffuse = Kd x lightColor x max(N · L, 0)
specular = Ks x lightColor x facing x (max(N · H, 0))

While the `PhongMaterial` followed this fairly closely, `DiffuseMaterial` was quite different. I went ahead and reworked `DiffuseMaterial` just to start giving some unifiormity to the material classes.

<h3> ToDo

-Extend this format to all material classes
