### PR TITLE
Fixed polygon facet bug for front-face culling mode

### DIFF
--- a/src/rajawali/BaseObject3D.java
+++ b/src/rajawali/BaseObject3D.java
@@ -241,10 +241,13 @@ public class BaseObject3D extends ATransformable3D implements Comparable<BaseObj
 			mProjMatrix = projMatrix;
 			if (!mDoubleSided) {
 				GLES20.glEnable(GLES20.GL_CULL_FACE);
-				if (mBackSided)
+				if (mBackSided) {
 					GLES20.glCullFace(GLES20.GL_FRONT);
-				else
+					GLES20.glFrontFace(GLES20.GL_CW);
+				} else {
 					GLES20.glCullFace(GLES20.GL_BACK);
+					GLES20.glFrontFace(GLES20.GL_CCW);
+				}
 			}
 			if (mEnableBlending && !(pickerInfo != null && mIsPickingEnabled)) {
 				GLES20.glEnable(GLES20.GL_BLEND);


### PR DESCRIPTION
When front-face culling is used, front-facing polygons are incorrectly assumed to be counter clockwise. This commit fixes vertex winding to be clockwise when front faces are culled and back faces are being shown.
