### PR TITLE
Gouraud light color

### DIFF
--- a/src/rajawali/materials/GouraudMaterial.java
+++ b/src/rajawali/materials/GouraudMaterial.java
@@ -24,6 +24,7 @@ public class GouraudMaterial extends AAdvancedMaterial {
 		"varying vec2 vTextureCoord;\n" +
 		"varying float vSpecularIntensity;\n" +
 		"varying float vDiffuseIntensity;\n" +
+		"varying vec3 vLightColor;\n" +
 		"varying vec4 vColor;\n" +
 		
 		M_FOG_VERTEX_VARS +
@@ -56,7 +57,7 @@ public class GouraudMaterial extends AAdvancedMaterial {
 		"%LIGHT_CODE%" +
 		"	vSpecularIntensity = clamp(vSpecularIntensity, 0.0, 1.0);\n" +
 		"#ifndef TEXTURED\n" +
-		"	vColor = aColor;\n" +
+		"	vColor = vec4(vLightColor, 1.0) * aColor;\n" +
 		"#endif\n" +
 		M_FOG_VERTEX_DENSITY +
 		"}";
@@ -67,6 +68,7 @@ public class GouraudMaterial extends AAdvancedMaterial {
 		"varying vec2 vTextureCoord;\n" +
 		"varying float vSpecularIntensity;\n" +
 		"varying float vDiffuseIntensity;\n" +
+		"varying vec3 vLightColor;\n" +
 		"varying vec4 vColor;\n" +
 		
 		"uniform sampler2D uDiffuseTexture;\n" +
@@ -80,7 +82,7 @@ public class GouraudMaterial extends AAdvancedMaterial {
 		
 		"void main() {\n" +
 		"#ifdef TEXTURED\n" +
-		"	vec4 texColor = texture2D(uDiffuseTexture, vTextureCoord);\n" +
+		"	vec4 texColor = vec4(vLightColor, 1.0) * texture2D(uDiffuseTexture, vTextureCoord);\n" +
 		"#else\n" +
 	    "	vec4 texColor = vColor;\n" +
 	    "#endif\n" +
@@ -146,6 +148,7 @@ public class GouraudMaterial extends AAdvancedMaterial {
 	public void setShaders(String vertexShader, String fragmentShader)
 	{
 		StringBuffer sb = new StringBuffer();
+		sb.append("float normPower = 0.0;\n");
 		
 		for(int i=0; i<mLights.size(); ++i) {
 			ALight light = mLights.get(i);
@@ -158,7 +161,9 @@ public class GouraudMaterial extends AAdvancedMaterial {
 				sb.append("L = normalize(-uLightDirection").append(i).append(");");
 			}
 			sb.append("NdotL = max(dot(N, L), 0.1);\n");
-			sb.append("vDiffuseIntensity += NdotL * attenuation * uLightPower").append(i).append(";\n");
+			sb.append("normPower += NdotL * attenuation * uLightPower").append(i).append(";\n");
+			sb.append("vDiffuseIntensity += normPower;\n");
+			sb.append("vLightColor +=normPower * uLightColor").append(i).append(";\n");
 			sb.append("vSpecularIntensity += pow(NdotL, 6.0) * attenuation * uLightPower").append(i).append(";\n");
 		}
 		


### PR DESCRIPTION
<h3> Reason

`GouraudMaterial` was not utilizing `uLightColor` when it could be. This functionality was previously added to `PhongMaterial` and `DiffuseMaterial`.

<h3> Method

A new varying type called `vLightColor` was added, and uses a similar calculation as `PhongMaterial` except done per-vertex. A varying was used so that light color could be computed with the sampled texture fragment.

<h3> Usage

Simply call `myLight.setColor(myLightColor)`. See `ALight` for more information. 
