### PR TITLE
Bumpmap materials fix

### DIFF
--- a/src/rajawali/materials/BumpmapMaterial.java
+++ b/src/rajawali/materials/BumpmapMaterial.java
@@ -58,6 +58,7 @@ public class BumpmapMaterial extends AAdvancedMaterial {
 				vc.append("vAttenuation").append(i).append(" = 1.0 / (uLightAttenuation").append(i).append("[1] + uLightAttenuation").append(i).append("[2] * dist + uLightAttenuation").append(i).append("[3] * dist * dist);\n");
 			} else if(light.getLightType() == ALight.DIRECTIONAL_LIGHT) {
 				fc.append("L = -normalize(uLightDirection").append(i).append(");");				
+				vc.append("vAttenuation").append(i).append(" = 1.0;\n");
 			}
 			fc.append("normPower = uLightPower").append(i).append(" * max(dot(bumpnormal, L), 0.1) * vAttenuation").append(i).append(";\n");
 			fc.append("intensity += normPower;\n");

--- a/src/rajawali/materials/BumpmapPhongMaterial.java
+++ b/src/rajawali/materials/BumpmapPhongMaterial.java
@@ -72,6 +72,7 @@ public class BumpmapPhongMaterial extends PhongMaterial {
 				vc.append("vAttenuation").append(i).append(" = 1.0 / (uLightAttenuation").append(i).append("[1] + uLightAttenuation").append(i).append("[2] * dist + uLightAttenuation").append(i).append("[3] * dist * dist);\n");
 			} else if(light.getLightType() == ALight.DIRECTIONAL_LIGHT) {
 				fc.append("L = normalize(-uLightDirection").append(i).append(");\n");
+				vc.append("vAttenuation").append(i).append(" = 1.0;\n");
 			}
 		
 			fc.append("NdotL = max(dot(bumpnormal, L), 0.1);\n");


### PR DESCRIPTION
<h3> Issue

https://github.com/MasDennis/Rajawali/issues/419

`BumpmapMaterial` and`BumpmapPhongMaterial` were throwing exceptions when used with a `DirectionalLight`. This was being caused by not using the varying `vAttenuation` within the vertex shader.

<h3> Method

Set `vAttenuation[i] = 1.0`in the fragment shader when a `DirectionalLight` is illuminating the object.

``` java
            } else if(light.getLightType() == ALight.DIRECTIONAL_LIGHT) {
                vc.append("vAttenuation").append(i).append(" = 1.0;\n");
```

<h3> Usage

No change to usage. It should just work now.
