### PR TITLE
Check if running on emulator

### DIFF
--- a/src/rajawali/RajawaliActivity.java
+++ b/src/rajawali/RajawaliActivity.java
@@ -13,6 +13,7 @@ import android.content.Context;
 import android.content.pm.ConfigurationInfo;
 import android.graphics.PixelFormat;
 import android.opengl.GLSurfaceView;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.View;
 import android.view.ViewGroup;
@@ -33,7 +34,7 @@ public class RajawaliActivity extends Activity {
         mSurfaceView = new GLSurfaceView(this);
         
         ActivityManager am = (ActivityManager)getSystemService(Context.ACTIVITY_SERVICE);
-        if(!Build.FINGERPRINT.startsWith(“generic”)) {
+        if(!Build.FINGERPRINT.startsWith("generic")) {
         	ConfigurationInfo info = am.getDeviceConfigurationInfo();
         	if(info.reqGlEsVersion < 0x20000)
         		throw new Error("OpenGL ES 2.0 is not supported by this device");


### PR DESCRIPTION
removed the unnecessary optional OpenGL ES 2 check that was added to circumvent a bug in the emulator in favor of a proper check if running on a emulator
