### PR TITLE
Bug fix - Relocated ambient light contribution in GouraudMaterial

### DIFF
--- a/src/rajawali/materials/GouraudMaterial.java
+++ b/src/rajawali/materials/GouraudMaterial.java
@@ -96,7 +96,7 @@ public class GouraudMaterial extends AAdvancedMaterial {
 		"#endif\n" +
 		
 		"	vec4 ambient = uAmbientIntensity * uAmbientColor;\n" + 	    
-		"	gl_FragColor = diffuse + specular;\n" +
+		"	gl_FragColor = diffuse + specular + ambient;\n" +
 		
 		"#ifdef ALPHA_MAP\n" +
 		"	float alpha = texture2D(uAlphaTexture, vTextureCoord).r;\n" +
@@ -104,7 +104,6 @@ public class GouraudMaterial extends AAdvancedMaterial {
 		"#else\n" +
 		"	gl_FragColor.a = diffuse.a;\n" +
 		"#endif\n" +
-		"	gl_FragColor += ambient;\n" +
 		M_FOG_FRAGMENT_COLOR +
 		"}";
 	


### PR DESCRIPTION
<h3> Reason

The ambient color equation was improperly placed after the alpha calculations. This caused the alpha to be set to 1.0 regardless of the alpha assigned. Oops, copy/paste SNAFU!

<h3> Method

Quick fix: simply moved the ambient color contribution into the `gl_fragColor` calculation.

<h3> Usage

No change
