### PR TITLE
Destroy method in IRendererPlugin

### DIFF
--- a/src/rajawali/renderer/plugins/IRendererPlugin.java
+++ b/src/rajawali/renderer/plugins/IRendererPlugin.java
@@ -10,6 +10,8 @@ package rajawali.renderer.plugins;
  * @author Andrew Jo
  */
 public interface IRendererPlugin {
+	public void destroy();
+	
 	public void reload();
 	
 	/**

--- a/src/rajawali/renderer/plugins/Plugin.java
+++ b/src/rajawali/renderer/plugins/Plugin.java
@@ -68,6 +68,18 @@ public abstract class Plugin implements IRendererPlugin {
 		return program;
 	}
 	
+	public void destroy() {
+		unload();
+	}
+	
+	protected int getUniformLocation(String name) {
+		return GLES20.glGetUniformLocation(mProgram, name);
+	}
+
+	protected int getAttribLocation(String name) {
+		return GLES20.glGetAttribLocation(mProgram, name);
+	}
+	
 	/**
 	 * Be sure to set up all the GL buffers and other initializations here.  
 	 */
@@ -118,6 +130,15 @@ public abstract class Plugin implements IRendererPlugin {
 		}
 		
 		mProgramCreated = true;
+	}
+	
+	/**
+	 * Unloads and deletes references to the shader program
+	 */
+	public void unload() {
+		GLES20.glDeleteShader(mVShaderHandle);
+		GLES20.glDeleteShader(mFShaderHandle);
+		GLES20.glDeleteProgram(mProgram);
 	}
 	
 	protected void useProgram(int programHandle) {


### PR DESCRIPTION
I forgot to include these changes in the last pull request which will occur in compile fail as RajawaliRenderer will look for a destroy method that doesn't exist.
