### PR TITLE
Prevent reloading of uninitialized PostProcessingRenderer in RajawaliRenderer

### DIFF
--- a/src/rajawali/renderer/PostProcessingRenderer.java
+++ b/src/rajawali/renderer/PostProcessingRenderer.java
@@ -151,6 +151,10 @@ public final class PostProcessingRenderer {
 		this.mEnabled = enabled;
 	}
 
+	public boolean isInitialized() {
+		return mEnabled;
+	}
+
 	public void setInitialized(boolean initialized) {
 		this.mInitialized = initialized;
 	}

--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -259,7 +259,8 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 			reloadChildren();
 			if(mSkybox != null)
 				mSkybox.reload();
-			mPostProcessingRenderer.reload();
+			if(mPostProcessingRenderer.isInitialized())
+				mPostProcessingRenderer.reload();
 			reloadPlugins();
 			mReloadPickerInfo = true;
 		}


### PR DESCRIPTION
If the PostProcessingRenderer has not been initialized and mTextureSize
is still set to -1, attempting to reload it will raise a GL error.
