### PR TITLE
Default state for BaseObject3D matricies

### DIFF
--- a/src/rajawali/BaseObject3D.java
+++ b/src/rajawali/BaseObject3D.java
@@ -80,7 +80,6 @@ public class BaseObject3D extends ATransformable3D implements Comparable<BaseObj
 		mGeometry = new Geometry3D();
 		mLights = new Stack<ALight>();
 		Matrix.setIdentityM(mMMatrix, 0);
-		Matrix.setIdentityM(mProjMatrix, 0);
 		Matrix.setIdentityM(mScalematrix, 0);
 		Matrix.setIdentityM(mTranslateMatrix, 0);
 		Matrix.setIdentityM(mRotateMatrix, 0);


### PR DESCRIPTION
I've got another small one for you guys. While working on implementing a scene graph architecture, I had need of being able to get an objects bounds in initScene(). Because the matrices are float arrays they are initialized to all zeros, which results in the bounds of the object being calculated as zero prior to the first frame being drawn. This adds a default state of the identity matrix to all the base model, scale, translate and rotate matrices (not the temp ones).
