### PR TITLE
Added default identity state to matrices in BaseObject3D

### DIFF
--- a/src/rajawali/BaseObject3D.java
+++ b/src/rajawali/BaseObject3D.java
@@ -81,6 +81,14 @@ public class BaseObject3D extends ATransformable3D implements Comparable<BaseObj
 		mChildren = Collections.synchronizedList(new CopyOnWriteArrayList<BaseObject3D>());
 		mGeometry = new Geometry3D();
 		mLights = Collections.synchronizedList(new CopyOnWriteArrayList<ALight>());
+		
+		//Initialize the matrices to identity
+		Matrix.setIdentityM(mMMatrix, 0);
+		Matrix.setIdentityM(mScalematrix, 0);
+		Matrix.setIdentityM(mRotateMatrix, 0);
+		Matrix.setIdentityM(mRotateMatrixTmp, 0);
+		Matrix.setIdentityM(mTranslateMatrix, 0);
+		Matrix.setIdentityM(mTmpMatrix, 0);
 	}
 
 	public BaseObject3D(String name) {


### PR DESCRIPTION
While working on implementing a scene graph architecture, I had need of being able to get an objects bounds in initScene(). Because the matrices are float arrays they are initialized to all zeros, which results in the bounds of the object being calculated as zero prior to the first frame being drawn. This adds a default state of the identity matrix to all the model, scale, translate and rotate matrices.
