### PR TITLE
Fixes issue #543 for mChildren in RajawaliRender. 

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -196,7 +196,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 
 		mCamera.updateFrustum(mPMatrix,mVMatrix); //update frustum plane
 
-		for (int i = 0, j = mChildren.size(); i < j; i++)
+		for (int i = 0; i < mChildren.size(); i++)
 			mChildren.get(i).render(mCamera, mPMatrix, mVMatrix, pickerInfo);
 
 		if (pickerInfo != null) {
@@ -270,7 +270,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 	}
 
 	private void reloadChildren() {
-		for (int i = 0, j = mChildren.size(); i < j; i++)
+		for (int i = 0; i < mChildren.size(); i++)
 			mChildren.get(i).reload();
 	}
 
@@ -288,7 +288,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 
 	protected void destroyScene() {
 		mSceneInitialized = false;
-		for (int i = 0, j = mChildren.size(); i < j; i++)
+		for (int i = 0; i < mChildren.size(); i++)
 			mChildren.get(i).destroy();
 		mChildren.clear();
 		for (int i = 0, j = mPlugins.size(); i < j; i++)
@@ -523,7 +523,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 
 	public void accept(INodeVisitor visitor) {
 		visitor.apply(this);
-		for (int i = 0, j = mChildren.size(); i < j; i++)
+		for (int i = 0; i < mChildren.size(); i++)
 			mChildren.get(i).accept(visitor);
 	}	
 
@@ -610,7 +610,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 
 	public int getNumTriangles() {
 		int triangleCount = 0;
-		for (int i=0,j=mChildren.size();i<j;i++) {
+		for (int i = 0; i < mChildren.size(); i++) {
 			if (mChildren.get(i).getGeometry() != null && mChildren.get(i).getGeometry().getVertices() != null && mChildren.get(i).isVisible())
 				triangleCount += mChildren.get(i).getGeometry().getVertices().limit() / 9;
 		}


### PR DESCRIPTION
For loops which iterate over mChildren now check the length on each cycle through the
loop. I did not include this for mPlugins because I can see no reason
why this would be changing at a frame by frame level. 

Signed-off-by: Jared Woolston jwoolston@tenkiv.com
