### PR TITLE
Fix texture coordinates for Plane primitive

### DIFF
--- a/src/rajawali/primitives/Plane.java
+++ b/src/rajawali/primitives/Plane.java
@@ -39,8 +39,8 @@ public class Plane extends BaseObject3D {
 				vertices[vertexCount + 1] = ((float) j / (float) mSegmentsH - 0.5f) * mHeight;
 				vertices[vertexCount + 2] = 0;
 
-				textureCoords[texCoordCount++] = (float) i / (float) mSegmentsW;
-				textureCoords[texCoordCount++] = 1.0f - (float) j / (float) mSegmentsH;
+				textureCoords[texCoordCount++] = (float) j / (float) mSegmentsW;
+				textureCoords[texCoordCount++] = 1.0f - (float) i / (float) mSegmentsH;
 
 				normals[vertexCount] = 0;
 				normals[vertexCount + 1] = 0;


### PR DESCRIPTION
The texture coordinates for the plane was rotated by default causing PostProcessingRenderer to display the framebuffer texture incorrectly. Also, other general textures on the plane would appear rotated. This is a simple fix that corrects the texture coordinates.
#### BEFORE FIX

![Screenshot_2013-04-21-16-28-30](https://f.cloud.github.com/assets/3170805/406153/abd3f6be-aa64-11e2-8aee-7cd853fff86a.png)
#### AFTER FIX

![Screenshot_2013-04-21-18-20-48](https://f.cloud.github.com/assets/3170805/406154/dcd1a5f4-aa64-11e2-87c7-f858a8c0ef5b.png)
