### PR TITLE
Damn simple texture loading

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -248,7 +248,7 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 		GLES20.glCullFace(GLES20.GL_BACK);
 
 		if (!mSceneInitialized) {
-			mTextureManager = new TextureManager();
+			mTextureManager = new TextureManager(mContext);
 			initScene();
 		}
 


### PR DESCRIPTION
This is mostly just a shortcut to the annoying bitmap loading. TextureManager now has access to the context passed by the renderer. Additionally this breaks implementations of the ETC1 loading as context is no longer required.
