### PR TITLE
Fixed bug when using multiple spot lights

### DIFF
--- a/src/rajawali/materials/DiffuseMaterial.java
+++ b/src/rajawali/materials/DiffuseMaterial.java
@@ -46,14 +46,14 @@ public class DiffuseMaterial extends AAdvancedMaterial {
 				vc.append("vAttenuation").append(i).append(" = (uLightAttenuation").append(i).append("[1] + uLightAttenuation").append(i).append("[2] * dist + uLightAttenuation").append(i).append("[3] * dist * dist);\n");
 				fc.append("L = normalize(uLightPosition").append(i).append(" - V.xyz);\n");
 				fc.append("vec3 spotDir").append(i).append(" = normalize(-uLightDirection").append(i).append(");\n");
-				fc.append("float spot_factor = dot( L, spotDir").append(i).append(" );\n");
+				fc.append("float spot_factor").append(i).append(" = dot( L, spotDir").append(i).append(" );\n");
 				fc.append("if( uSpotCutoffAngle").append(i).append(" < 180.0 ) {\n");
-					fc.append("if( spot_factor >= cos( radians( uSpotCutoffAngle").append(i).append(") ) ) {\n");
-						fc.append("spot_factor = (1.0 - (1.0 - spot_factor) * 1.0/(1.0 - cos( radians( uSpotCutoffAngle").append(i).append("))));\n");
-						fc.append("spot_factor = pow(spot_factor, uSpotFalloff").append(i).append("* 1.0/spot_factor);\n");
+					fc.append("if( spot_factor").append(i).append(" >= cos( radians( uSpotCutoffAngle").append(i).append(") ) ) {\n");
+						fc.append("spot_factor").append(i).append(" = (1.0 - (1.0 - spot_factor").append(i).append(") * 1.0/(1.0 - cos( radians( uSpotCutoffAngle").append(i).append("))));\n");
+						fc.append("spot_factor").append(i).append(" = pow(spot_factor").append(i).append(", uSpotFalloff").append(i).append("* 1.0/spot_factor").append(i).append(");\n");
 					fc.append("}\n");
 					fc.append("else {\n");
-						fc.append("spot_factor = 0.0;\n");
+						fc.append("spot_factor").append(i).append(" = 0.0;\n");
 					fc.append("}\n");
 					fc.append("L = vec3(L.y, L.x, L.z);\n");
 					fc.append("}\n");
@@ -67,7 +67,7 @@ public class DiffuseMaterial extends AAdvancedMaterial {
 			fc.append("intensity += power;\n"); 
 			
 			if(light.getLightType() == ALight.SPOT_LIGHT)
-				fc.append("Kd.rgb += uLightColor").append(i).append(" * spot_factor;\n");
+				fc.append("Kd.rgb += uLightColor").append(i).append(" * spot_factor").append(i).append(";\n");
 			else
 				fc.append("Kd.rgb += uLightColor").append(i).append(" * power;\n");
 		}

--- a/src/rajawali/materials/GouraudMaterial.java
+++ b/src/rajawali/materials/GouraudMaterial.java
@@ -79,14 +79,14 @@ public class GouraudMaterial extends AAdvancedMaterial {
 				vc.append("attenuation = (uLightAttenuation").append(i).append("[1] + uLightAttenuation").append(i).append("[2] * dist + uLightAttenuation").append(i).append("[3] * dist * dist);\n");
 				vc.append("L = normalize(uLightPosition").append(i).append(" + E);\n");
 				vc.append("vec3 spotDir").append(i).append(" = normalize(-uLightDirection").append(i).append(");\n");
-				vc.append("float spot_factor = dot( L, spotDir").append(i).append(" );\n");
+				vc.append("float spot_factor").append(i).append(" = dot( L, spotDir").append(i).append(" );\n");
 				vc.append("if( uSpotCutoffAngle").append(i).append(" < 180.0 ) {\n");
-					vc.append("if( spot_factor >= cos( radians( uSpotCutoffAngle").append(i).append(") ) ) {\n");
-						vc.append("spot_factor = (1.0 - (1.0 - spot_factor) * 1.0/(1.0 - cos( radians( uSpotCutoffAngle").append(i).append("))));\n");
-						vc.append("spot_factor = pow(spot_factor, uSpotFalloff").append(i).append("* 1.0/spot_factor);\n");
+					vc.append("if( spot_factor").append(i).append(" >= cos( radians( uSpotCutoffAngle").append(i).append(") ) ) {\n");
+						vc.append("spot_factor").append(i).append(" = (1.0 - (1.0 - spot_factor").append(i).append(") * 1.0/(1.0 - cos( radians( uSpotCutoffAngle").append(i).append("))));\n");
+						vc.append("spot_factor").append(i).append(" = pow(spot_factor").append(i).append(", uSpotFalloff").append(i).append("* 1.0/spot_factor").append(i).append(");\n");
 					vc.append("}\n");
 					vc.append("else {\n");
-						vc.append("spot_factor = 0.0;\n");
+						vc.append("spot_factor").append(i).append(" = 0.0;\n");
 					vc.append("}\n");
 					vc.append("L = vec3(L.y, L.x, L.z);\n");
 					vc.append("}\n");
@@ -97,8 +97,8 @@ public class GouraudMaterial extends AAdvancedMaterial {
 			vc.append("power = NdotL * attenuation * uLightPower").append(i).append(";\n");
 			vc.append("vDiffuseIntensity += power;\n");
 			if(light.getLightType() == ALight.SPOT_LIGHT){
-				vc.append("vLightColor += uLightColor").append(i).append(" * spot_factor;\n");
-				vc.append("vSpecularIntensity += pow(NdotL, 6.0) * spot_factor;\n");
+				vc.append("vLightColor += uLightColor").append(i).append(" * spot_factor").append(i).append(";\n");
+				vc.append("vSpecularIntensity += pow(NdotL, 6.0) * spot_factor").append(i).append(";\n");
 			}
 			else{
 				vc.append("vLightColor += power * uLightColor").append(i).append(";\n");

--- a/src/rajawali/materials/PhongMaterial.java
+++ b/src/rajawali/materials/PhongMaterial.java
@@ -97,14 +97,14 @@ public class PhongMaterial extends AAdvancedMaterial {
 				vc.append("vAttenuation").append(i).append(" = (uLightAttenuation").append(i).append("[1] + uLightAttenuation").append(i).append("[2] * dist + uLightAttenuation").append(i).append("[3] * dist * dist);\n");
 				fc.append("L = normalize(uLightPosition").append(i).append(" + vEyeVec);\n");
 				fc.append("vec3 spotDir").append(i).append(" = normalize(-uLightDirection").append(i).append(");\n");
-				fc.append("float spot_factor = dot( L, spotDir").append(i).append(" );\n");
+				fc.append("float spot_factor").append(i).append(" = dot( L, spotDir").append(i).append(" );\n");
 				fc.append("if( uSpotCutoffAngle").append(i).append(" < 180.0 ) {\n");
-					fc.append("if( spot_factor >= cos( radians( uSpotCutoffAngle").append(i).append(") ) ) {\n");
-						fc.append("spot_factor = (1.0 - (1.0 - spot_factor) * 1.0/(1.0 - cos( radians( uSpotCutoffAngle").append(i).append("))));\n");
-						fc.append("spot_factor = pow(spot_factor, uSpotFalloff").append(i).append("* 1.0/spot_factor);\n");
+					fc.append("if( spot_factor").append(i).append(" >= cos( radians( uSpotCutoffAngle").append(i).append(") ) ) {\n");
+						fc.append("spot_factor").append(i).append(" = (1.0 - (1.0 - spot_factor").append(i).append(") * 1.0/(1.0 - cos( radians( uSpotCutoffAngle").append(i).append("))));\n");
+						fc.append("spot_factor").append(i).append(" = pow(spot_factor").append(i).append(", uSpotFalloff").append(i).append("* 1.0/spot_factor").append(i).append(");\n");
 					fc.append("}\n");
 					fc.append("else {\n");
-						fc.append("spot_factor = 0.0;\n");
+						fc.append("spot_factor").append(i).append(" = 0.0;\n");
 					fc.append("}\n");
 					fc.append("L = vec3(L.y, -L.x, L.z);\n");
 					fc.append("}\n");
@@ -117,8 +117,8 @@ public class PhongMaterial extends AAdvancedMaterial {
 			fc.append("power = uLightPower").append(i).append(" * NdotL * vAttenuation").append(i).append(";\n");
 			fc.append("intensity += power;\n"); 
 			if(light.getLightType() == ALight.SPOT_LIGHT){
-				fc.append("Kd.rgb += uLightColor").append(i).append(" * spot_factor * power;\n");
-				fc.append("Ks += pow(NdotL, uShininess) * spot_factor * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n");
+				fc.append("Kd.rgb += uLightColor").append(i).append(" * spot_factor").append(i).append(" * power;\n");
+				fc.append("Ks += pow(NdotL, uShininess) * spot_factor").append(i).append(" * vAttenuation").append(i).append(" * uLightPower").append(i).append(";\n");
 			}
 			else{
 				fc.append("Kd.rgb += uLightColor").append(i).append(" * power;\n"); 


### PR DESCRIPTION
<h3>Issue

As reported by @jwoolston in the revived thread of https://github.com/MasDennis/Rajawali/issues/227, shaders will fail to compile when using multiple spot lights. This was caused by `spot_factor` lacking an index within the light loops.

<h3> Resolution

This change appends an index to `spot_factor` in each of the base materials so that multiple spot lights can now be used. It does not impact `RajawaliExamples` since it does not utilize this light type.
