### PR TITLE
Animations could potentially crash due to removing or adding listeners during playback.

### DIFF
--- a/src/rajawali/animation/Animation3D.java
+++ b/src/rajawali/animation/Animation3D.java
@@ -144,10 +144,14 @@ public abstract class Animation3D {
 	/**
 	 * Register a listener for animations. Use {@link #unregisterListener(IAnimation3DListener)} to remove a listener.
 	 * 
+	 * @throws RuntimeException Thrown when called while animation {@link #isPlaying()} is true
 	 * @param animationListener
 	 * @return
 	 */
 	public boolean registerListener(IAnimation3DListener animationListener) {
+		if (isPlaying())
+			throw new RuntimeException("Listeners can only be added and removed when the animation is not playing.");
+		
 		return mAnimationListeners.add(animationListener);
 	}
 
@@ -264,10 +268,14 @@ public abstract class Animation3D {
 	 * Unregister a given listener. Use {@link #registerListener(IAnimation3DListener)} to add a listener. Returns true
 	 * on success.
 	 * 
+	 * @throws RuntimeException Thrown when called while animation {@link #isPlaying()} is true 
 	 * @param animationListener
 	 * @return {@link Boolean}
 	 */
 	public boolean unregisterListener(IAnimation3DListener animationListener) {
+		if (isPlaying())
+			throw new RuntimeException("Listeners can only be added and removed when the animation is not playing.");
+			
 		return mAnimationListeners.remove(animationListener);
 	}
 


### PR DESCRIPTION
Instead of a complex queue system I opted to just throw exceptions if changes are made during playback.
