### PR TITLE
Fixed concurrency bug

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -341,8 +341,9 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 		mCamera.updateFrustum(mPMatrix,mVMatrix); //update frustum plane
 		
 		// Update all registered animations
-		for (int i = 0, j = mAnimations.size(); i < j; i++)
+		for (int i = 0; i < mAnimations.size(); i++) {
 			mAnimations.get(i).update(deltaTime);
+		}
 
 		for (int i = 0; i < mChildren.size(); i++)
 			mChildren.get(i).render(mCamera, mPMatrix, mVMatrix, pickerInfo);


### PR DESCRIPTION
`mAnimations.size()` needs to be evaluated at every iteration just like the `mChildren` iteration loop below to ensure the size is updated right away when animations are registered and unregistered dynamically.
