### PR TITLE
Added a check to only update when animation is playing

### DIFF
--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -342,7 +342,9 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 		
 		// Update all registered animations
 		for (int i = 0; i < mAnimations.size(); i++) {
-			mAnimations.get(i).update(deltaTime);
+			Animation3D anim = mAnimations.get(i);
+			if (anim.isPlaying())
+				anim.update(deltaTime);
 		}
 
 		for (int i = 0; i < mChildren.size(); i++)


### PR DESCRIPTION
Currently, if you play two different animations one after another on a same object in different order than they were registered, the first animation that ended overwrites the second animation's transformation value with its last value.

Added a quick check to only update when isPlaying is set to true.
