### PR TITLE
Long animations names cant exist without being cropped down to 6 chars

### DIFF
--- a/src/rajawali/parser/MD2Parser.java
+++ b/src/rajawali/parser/MD2Parser.java
@@ -189,7 +189,7 @@ public class MD2Parser extends AMeshParser implements IAnimatedMeshParser {
 			if (name.indexOf("_") > 0)
 				name = name.subSequence(0, name.lastIndexOf("_")).toString();
 			else
-				name = name.substring(0, 6).replaceAll("[0-9]{1,2}$", "");
+				name = name.trim().replaceAll("[0-9]{1,2}$", "");
 			frame.setName(name);
 
 			float vertices[] = new float[mHeader.numVerts * 3];


### PR DESCRIPTION
-- Animation names longer than 6 characters were cropped without this fix.

Hey again,

I just figured out that the animation names in MD2 files, longer than 6 characters are being destroyed, kind of. Everything is shortened to 6 characters. e.g. "running" becomes "runnin" internally, and therefore player.play("running", true); does not work.

The culprit is in rajawali.parser.MD2Parser.class, line 192
`name = name.substring(0, 6).replaceAll("[0-9]{1,2}$", "");`

There should be a better way to read the filenames. My approach is:
`name = name.trim().replaceAll("[0-9]{1,2}$", "");`

Pull request is send.
