### PR TITLE
Fixes #644

### DIFF
--- a/src/rajawali/Geometry3D.java
+++ b/src/rajawali/Geometry3D.java
@@ -400,6 +400,7 @@ public class Geometry3D {
 		if(type == BufferType.SHORT_BUFFER)
 			byteSize = SHORT_SIZE_BYTES;
 		
+		buffer.rewind();
 		GLES20.glBindBuffer(target, handle);
 		GLES20.glBufferData(target, buffer.limit() * byteSize, buffer, usage);
 		GLES20.glBindBuffer(target, 0);


### PR DESCRIPTION
Needed to call buffer.rewind() prior to binding.

Signed-off-by: Jared Woolston jwoolston@tenkiv.com
