### PR TITLE
RFC: Introducing RajawaliScene!

### DIFF
--- a/src/rajawali/ATransformable3D.java
+++ b/src/rajawali/ATransformable3D.java
@@ -1,12 +1,16 @@
 package rajawali;
 
+import rajawali.bounds.IBoundingVolume;
 import rajawali.math.AngleAxis;
 import rajawali.math.Number3D;
 import rajawali.math.Number3D.Axis;
 import rajawali.math.Quaternion;
+import rajawali.renderer.AFrameTask;
+import rajawali.scenegraph.IGraphNode;
+import rajawali.scenegraph.IGraphNodeMember;
 import android.opengl.Matrix;
 
-public abstract class ATransformable3D {
+public abstract class ATransformable3D extends AFrameTask implements IGraphNodeMember {
 	protected Number3D mPosition, mRotation, mScale;
 	protected Quaternion mOrientation;
 	protected Quaternion mTmpOrientation;
@@ -17,6 +21,9 @@ public abstract class ATransformable3D {
 	protected Number3D mTmpAxis, mTmpVec;
 	protected boolean mIsCamera, mQuatWasSet;
 	protected AngleAxis mAngleAxis; 
+	
+	protected IGraphNode mGraphNode;
+	protected boolean mInsideGraph = false; //Default to being outside the graph
 	
 	public ATransformable3D() {
 		mPosition = new Number3D();
@@ -35,10 +42,12 @@ public abstract class ATransformable3D {
 	
 	public void setPosition(Number3D position) {
 		mPosition.setAllFrom(position);
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public void setPosition(float x, float y, float z) {
 		mPosition.setAll(x, y, z);
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public Number3D getPosition() {
@@ -47,6 +56,7 @@ public abstract class ATransformable3D {
 	
 	public void setX(float x) {
 		mPosition.x = x;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public float getX() {
@@ -55,6 +65,7 @@ public abstract class ATransformable3D {
 
 	public void setY(float y) {
 		mPosition.y = y;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public float getY() {
@@ -63,6 +74,7 @@ public abstract class ATransformable3D {
 
 	public void setZ(float z) {
 		mPosition.z = z;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public float getZ() {
@@ -116,6 +128,7 @@ public abstract class ATransformable3D {
 			if(mIsCamera)
 				mOrientation.inverseSelf();
 		}
+		//if (mGraphNode != null) mGraphNode.updateObject(this); //TODO: This may cause problems
 	}
 
 	public void rotateAround(Number3D axis, float angle) {
@@ -130,6 +143,7 @@ public abstract class ATransformable3D {
  			mOrientation.fromAngleAxis(angle, axis);
  		}
 		mRotationDirty = false;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 	
 	public Quaternion getOrientation() {
@@ -140,6 +154,7 @@ public abstract class ATransformable3D {
 	public void setOrientation(Quaternion quat) {
 		mOrientation.setAllFrom(quat);
 		mRotationDirty = false;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 	
 	public void setRotation(float rotX, float rotY, float rotZ) {
@@ -147,6 +162,7 @@ public abstract class ATransformable3D {
 		mRotation.y = rotY;
 		mRotation.z = rotZ;
 		mRotationDirty = true;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 	
 	public void setRotX(float rotX) {
@@ -189,16 +205,19 @@ public abstract class ATransformable3D {
 		mScale.x = scale;
 		mScale.y = scale;
 		mScale.z = scale;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public void setScale(float scaleX, float scaleY, float scaleZ) {
 		mScale.x = scaleX;
 		mScale.y = scaleY;
 		mScale.z = scaleZ;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public void setScaleX(float scaleX) {
 		mScale.x = scaleX;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public float getScaleX() {
@@ -207,6 +226,7 @@ public abstract class ATransformable3D {
 
 	public void setScaleY(float scaleY) {
 		mScale.y = scaleY;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public float getScaleY() {
@@ -215,6 +235,7 @@ public abstract class ATransformable3D {
 
 	public void setScaleZ(float scaleZ) {
 		mScale.z = scaleZ;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public float getScaleZ() {
@@ -227,6 +248,7 @@ public abstract class ATransformable3D {
 
 	public void setScale(Number3D scale) {
 		mScale = scale;
+		if (mGraphNode != null) mGraphNode.updateObject(this);
 	}
 
 	public Number3D getLookAt() {
@@ -247,5 +269,46 @@ public abstract class ATransformable3D {
 			return;
 		}
 		setLookAt(lookAt.x,  lookAt.y, lookAt.z);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNodeMember#setGraphNode(rajawali.scenegraph.IGraphNode)
+	 */
+	public void setGraphNode(IGraphNode node, boolean inside) {
+		mGraphNode = node;
+		mInsideGraph = inside;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNodeMember#getGraphNode()
+	 */
+	public IGraphNode getGraphNode() {
+		return mGraphNode;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNodeMember#isInGraph()
+	 */
+	public boolean isInGraph() {
+		return mInsideGraph;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNodeMember#getTransformedBoundingVolume()
+	 */
+	public IBoundingVolume getTransformedBoundingVolume() {
+		return null;
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNodeMember#getScenePosition()
+	 */
+	public Number3D getScenePosition() {
+		return mPosition;
 	}
 }

--- a/src/rajawali/Camera.java
+++ b/src/rajawali/Camera.java
@@ -1,9 +1,11 @@
 package rajawali;
 
+import rajawali.bounds.IBoundingVolume;
 import rajawali.math.MathUtil;
 import rajawali.math.Number3D;
 import rajawali.math.Number3D.Axis;
 import rajawali.math.Quaternion;
+import rajawali.renderer.AFrameTask;
 import android.opengl.Matrix;
 
 public class Camera extends ATransformable3D {
@@ -307,5 +309,19 @@ public class Camera extends ATransformable3D {
 
 	public void setFogEnabled(boolean fogEnabled) {
 		this.mFogEnabled = fogEnabled;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.ATransformable3D#getTransformedBoundingVolume()
+	 */
+	@Override
+	public IBoundingVolume getTransformedBoundingVolume() {
+		return mFrustum.getBoundingBox();
+	}
+	
+	@Override
+	public TYPE getFrameTaskType() {
+		return AFrameTask.TYPE.CAMERA;
 	}
 }

--- a/src/rajawali/Frustum.java
+++ b/src/rajawali/Frustum.java
@@ -5,10 +5,13 @@ import rajawali.math.Number3D;
 import rajawali.math.Plane;
 import rajawali.math.Plane.PlaneSide;
 import rajawali.primitives.Sphere;
+import android.opengl.Matrix;
+import android.util.Log;
 
 public class Frustum {
 	private Number3D[] mTmp = new Number3D[8];
 	protected Sphere mVisualSphere;
+	protected BoundingBox mBoundingBox;
 	protected float[] mTmpMatrix = new float[16];
 	protected static final Number3D[] mClipSpacePlanePoints = { 
 		new Number3D(-1, -1, -1), 
@@ -39,7 +42,7 @@ public class Frustum {
 
 		for(int i = 0; i < 8; i++) {
 			planePoints[i].setAllFrom(mClipSpacePlanePoints[i]);
-			planePoints[i].project(inverseProjectionView);                    
+			planePoints[i].project(inverseProjectionView);   
 		}
 
 		planes[0].set(planePoints[1], planePoints[0], planePoints[2]);
@@ -48,6 +51,7 @@ public class Frustum {
 		planes[3].set(planePoints[5], planePoints[1], planePoints[6]);
 		planes[4].set(planePoints[2], planePoints[3], planePoints[6]);
 		planes[5].set(planePoints[4], planePoints[0], planePoints[1]);
+		setBounds();
 	}       
 
 
@@ -81,5 +85,42 @@ public class Frustum {
 			if (result == PlaneSide.Back) {return false;}
 		}
 		return true;
+	}
+	
+	/**
+	 * Sets the bounds of the frustum's BoundingBox.
+	 * Should be called internally whenever a change to
+	 * the frustum occurs.
+	 */
+	protected void setBounds() {
+		if (mBoundingBox == null) {
+			mBoundingBox = new BoundingBox();
+		}
+		Number3D min = new Number3D();
+		Number3D max = new Number3D();
+		min.setAllFrom(planePoints[0]);
+		min.x = planePoints[5].x;
+		min.y = planePoints[5].y;
+		max.setAllFrom(planePoints[7]);
+		//Log.i("Rajawali", "Min/Max: " + min + "/" + max);
+		Matrix.setIdentityM(mTmpMatrix, 0);
+		mBoundingBox.setMin(min);
+		mBoundingBox.setMax(max);
+		mBoundingBox.calculatePoints();
+		mBoundingBox.transform(mTmpMatrix);
+		//Log.i("Rajawali", "Camera bounds: " + mBoundingBox);
+	}
+	
+	/**
+	 * Returns a BoundingBox representative of this frustum.
+	 * This will create the BoundingBox if necessary.
+	 * 
+	 * @return BoundingBox which contains this frustum.
+	 */
+	public BoundingBox getBoundingBox() {
+		if (mBoundingBox == null) {
+			setBounds();
+		} 
+		return mBoundingBox;
 	}
 }

--- a/src/rajawali/animation/Animation3D.java
+++ b/src/rajawali/animation/Animation3D.java
@@ -4,10 +4,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import rajawali.ATransformable3D;
+import rajawali.renderer.AFrameTask;
 import android.view.animation.Interpolator;
 import android.view.animation.LinearInterpolator;
 
-public abstract class Animation3D {
+public abstract class Animation3D extends AFrameTask {
 
 	public enum RepeatMode {
 		NONE, INFINITE, RESTART, REVERSE, REVERSE_INFINITE
@@ -391,6 +392,10 @@ public abstract class Animation3D {
 	protected void eventUpdate(double interpolatedTime) {
 		for (int i = 0, j = mAnimationListeners.size(); i < j; i++)
 			mAnimationListeners.get(i).onAnimationUpdate(this, interpolatedTime);
+	}
+
+	public AFrameTask.TYPE getFrameTaskType() {
+		return AFrameTask.TYPE.ANIMATION;
 	}
 
 }

--- a/src/rajawali/animation/ScaleAnimation3D.java
+++ b/src/rajawali/animation/ScaleAnimation3D.java
@@ -38,8 +38,7 @@ public class ScaleAnimation3D extends Animation3D {
 		mMultipliedScale.multiply((float) mInterpolatedTime);
 		mAddedScale.setAllFrom(mFromScale);
 		mAddedScale.add(mMultipliedScale);
-
-		mTransformable3D.getScale().setAllFrom(mAddedScale);
+		mTransformable3D.setScale(mAddedScale);
 	}
 
 }

--- a/src/rajawali/animation/TranslateAnimation3D.java
+++ b/src/rajawali/animation/TranslateAnimation3D.java
@@ -45,9 +45,10 @@ public class TranslateAnimation3D extends Animation3D {
 			mMultipliedPosition.multiply((float) mInterpolatedTime);
 			mAddedPosition.setAllFrom(mFromPosition);
 			mAddedPosition.add(mMultipliedPosition);
-			mTransformable3D.getPosition().setAllFrom(mAddedPosition);
+			mTransformable3D.setPosition(mAddedPosition);
 		} else {
 			Number3D pathPoint = mSplinePath.calculatePoint((float) mInterpolatedTime);
+			mTransformable3D.setPosition(pathPoint);
 			mTransformable3D.getPosition().setAllFrom(pathPoint);
 
 			if (mOrientToPath)

--- a/src/rajawali/bounds/BoundingBox.java
+++ b/src/rajawali/bounds/BoundingBox.java
@@ -1,6 +1,7 @@
 package rajawali.bounds;
 
 import java.nio.FloatBuffer;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import rajawali.BaseObject3D;
 import rajawali.Camera;
@@ -21,6 +22,7 @@ public class BoundingBox implements IBoundingVolume {
 	protected int mI;
 	protected Cube mVisualBox;
 	protected float[] mTmpMatrix = new float[16];
+	protected AtomicInteger mBoundingColor = new AtomicInteger(0xffffff00);
 	
 	public void copyPoints(Number3D[] pts){
 		
@@ -68,7 +70,7 @@ public class BoundingBox implements IBoundingVolume {
 			mVisualBox = new Cube(1);
 			mVisualBox.setMaterial(new SimpleMaterial());
 			mVisualBox.getMaterial().setUseColor(true);
-			mVisualBox.setColor(0xffffff00);
+			mVisualBox.setColor(mBoundingColor.get());
 			mVisualBox.setDrawingMode(GLES20.GL_LINE_LOOP);
 		}
 		
@@ -83,6 +85,7 @@ public class BoundingBox implements IBoundingVolume {
 				mTransformedMin.y + (mTransformedMax.y - mTransformedMin.y) * .5f, 
 				mTransformedMin.z + (mTransformedMax.z - mTransformedMin.z) * .5f
 				);
+		
 		mVisualBox.render(camera, projMatrix, vMatrix, mTmpMatrix, null);
 	}
 	
@@ -94,6 +97,17 @@ public class BoundingBox implements IBoundingVolume {
 	
 	public BaseObject3D getVisual() {
 		return mVisualBox;
+	}
+	
+	public void setBoundingColor(int color) {
+		mBoundingColor.set(color);
+		if (mVisualBox != null) {
+			mVisualBox.setColor(color);
+		}
+	}
+	
+	public int getBoundingColor() {
+		return mBoundingColor.get();
 	}
 	
 	public void calculateBounds(Geometry3D geometry) {
@@ -118,6 +132,10 @@ public class BoundingBox implements IBoundingVolume {
 			if(vertex.z > mMax.z) mMax.z = vertex.z;
 		}
 		
+		calculatePoints();
+	}
+	
+	public void calculatePoints() {
 		// -- bottom plane
 		// -- -x, -y, -z
 		mPoints[0].setAll(mMin.x, mMin.y, mMin.z);
@@ -127,7 +145,7 @@ public class BoundingBox implements IBoundingVolume {
 		mPoints[2].setAll(mMax.x, mMin.y, mMax.z);
 		// --  x, -y, -z
 		mPoints[3].setAll(mMax.x, mMin.y, mMin.z);
-		
+
 		// -- top plane
 		// -- -x,  y, -z
 		mPoints[4].setAll(mMin.x, mMax.y, mMin.z);
@@ -195,7 +213,42 @@ public class BoundingBox implements IBoundingVolume {
 				(min.z < otherMax.z) && (max.z > otherMin.z);
 	}
 	
+	@Override
 	public String toString() {
 		return "BoundingBox min: " + mTransformedMin + " max: " + mTransformedMax;
 	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.bounds.IBoundingVolume#contains(rajawali.bounds.IBoundingVolume)
+	 */
+	/*public boolean contains(IBoundingVolume boundingVolume) {
+		if(!(boundingVolume instanceof BoundingBox)) return false;
+		BoundingBox boundingBox = (BoundingBox)boundingVolume;
+		Number3D otherMin = boundingBox.getTransformedMin();
+		Number3D otherMax = boundingBox.getTransformedMax();
+		Number3D min = mTransformedMin;
+		Number3D max = mTransformedMax;		
+		
+		return (max.x >= otherMax.x) && (min.x <= otherMin.x) &&
+				(max.y >= otherMax.y) && (min.y <= otherMin.y) &&
+				(max.z >= otherMax.z) && (min.z <= otherMin.z);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.bounds.IBoundingVolume#isContainedBy(rajawali.bounds.IBoundingVolume)
+	 */
+	/*public boolean isContainedBy(IBoundingVolume boundingVolume) {
+		if(!(boundingVolume instanceof BoundingBox)) return false;
+		BoundingBox boundingBox = (BoundingBox)boundingVolume;
+		Number3D otherMin = boundingBox.getTransformedMin();
+		Number3D otherMax = boundingBox.getTransformedMax();
+		Number3D min = mTransformedMin;
+		Number3D max = mTransformedMax;		
+		
+		return (max.x <= otherMax.x) && (min.x >= otherMin.x) &&
+				(max.y <= otherMax.y) && (min.y >= otherMin.y) &&
+				(max.z <= otherMax.z) && (min.z >= otherMin.z);
+	}*/
 }

--- a/src/rajawali/bounds/BoundingSphere.java
+++ b/src/rajawali/bounds/BoundingSphere.java
@@ -20,6 +20,7 @@ public class BoundingSphere implements IBoundingVolume {
 	protected Number3D mTmpPos;
 	protected float mDist, mMinDist, mScale;
 	protected float[] mScaleValues;
+	protected int mBoundingColor = 0xffffff00;
 	
 	public BoundingSphere() {
 		super();
@@ -36,6 +37,14 @@ public class BoundingSphere implements IBoundingVolume {
 	
 	public BaseObject3D getVisual() {
 		return mVisualSphere;
+	}
+	
+	public void setBoundingColor(int color) {
+		mBoundingColor = color;
+	}
+	
+	public int getBoundingColor() {
+		return mBoundingColor;
 	}
 	
 	public void drawBoundingVolume(Camera camera, float[] projMatrix, float[] vMatrix, float[] mMatrix) {
@@ -89,12 +98,21 @@ public class BoundingSphere implements IBoundingVolume {
 		return mRadius;
 	}
 	
+	public float getScaledRadius() {
+		return (mRadius*mScale);
+	}
+	
 	public Number3D getPosition() {
 		return mPosition;
 	}
 	
 	public float getScale() {
 		return mScale;
+	}
+	
+	@Override
+	public String toString() {
+		return "BoundingSphere radius: " + Float.toString(getScaledRadius());
 	}
 	
 	public boolean intersectsWith(IBoundingVolume boundingVolume) {
@@ -109,4 +127,14 @@ public class BoundingSphere implements IBoundingVolume {
 		
 		return mDist < mMinDist * mMinDist;
 	}
+
+	/*public boolean contains(IBoundingVolume boundingVolume) {
+		// TODO Auto-generated method stub
+		return false;
+	}
+
+	public boolean isContainedBy(IBoundingVolume boundingVolume) {
+		// TODO Auto-generated method stub
+		return false;
+	}*/
 }

--- a/src/rajawali/bounds/IBoundingVolume.java
+++ b/src/rajawali/bounds/IBoundingVolume.java
@@ -5,9 +5,15 @@ import rajawali.Camera;
 import rajawali.Geometry3D;
 
 public interface IBoundingVolume {
+	
+	public static final int DEFAULT_COLOR = 0xFFFFFF00;
+	
 	public void calculateBounds(Geometry3D geometry);
 	public void drawBoundingVolume(Camera camera, float[] projMatrix, float[] vMatrix, float[] mMatrix);
 	public void transform(float[] matrix);
 	public boolean intersectsWith(IBoundingVolume boundingVolume);
+	
 	public BaseObject3D getVisual();
+	public void setBoundingColor(int color);
+	public int getBoundingColor();
 }

--- a/src/rajawali/lights/ALight.java
+++ b/src/rajawali/lights/ALight.java
@@ -2,6 +2,7 @@ package rajawali.lights;
 
 import rajawali.ATransformable3D;
 import rajawali.math.Number3D;
+import rajawali.renderer.AFrameTask;
 
 public abstract class ALight extends ATransformable3D {
 	public static final int DIRECTIONAL_LIGHT = 0;
@@ -72,5 +73,10 @@ public abstract class ALight extends ATransformable3D {
 		mPositionArray[1] = mPosition.y;
 		mPositionArray[2] = mPosition.z;
 		return mPositionArray;
+	}
+	
+	@Override
+	public AFrameTask.TYPE getFrameTaskType() {
+		return AFrameTask.TYPE.LIGHT;
 	}
 }

--- a/src/rajawali/math/Number3D.java
+++ b/src/rajawali/math/Number3D.java
@@ -116,6 +116,12 @@ public class Number3D {
 		return new Number3D(-x, -y, -z);
 	}
 	
+	public void absoluteValue() {
+		x = Math.abs(x);
+		y = Math.abs(y);
+		z = Math.abs(z);
+	}
+	
 	public Number3D add(Number3D n) {
 		this.x += n.x;
 		this.y += n.y;

--- a/src/rajawali/parser/fbx/FBXParser.java
+++ b/src/rajawali/parser/fbx/FBXParser.java
@@ -145,8 +145,8 @@ public class FBXParser extends AMeshParser {
 		}
 		
 		// -- check fog
-		
-		if(mFbx.version5.fogOptions.fogEnable != null && mFbx.version5.fogOptions.fogEnable == 1) {
+		//TODO: FIX
+		/*if(mFbx.version5.fogOptions.fogEnable != null && mFbx.version5.fogOptions.fogEnable == 1) {
 			FogOptions fogOptions = mFbx.version5.fogOptions;
 			mRenderer.setFogEnabled(true);
 			Camera cam = mRenderer.getCamera();
@@ -154,7 +154,7 @@ public class FBXParser extends AMeshParser {
 			cam.setFogNear(fogOptions.fogStart);
 			cam.setFogColor(fogOptions.fogColor.color);
 			mRenderer.setBackgroundColor(fogOptions.fogColor.color);
-		}
+		}*/
 	
 		// -- get meshes
 		
@@ -177,7 +177,7 @@ public class FBXParser extends AMeshParser {
 			}
 		}
 
-		if(camera != null) {
+		/*if(camera != null) { //TODO: FIX
 			Camera cam = mRenderer.getCamera();
 			cam.setPosition(camera.position);
 			cam.setX(mRenderer.getCamera().getX() * -1);
@@ -187,7 +187,7 @@ public class FBXParser extends AMeshParser {
 			cam.setNearPlane(camera.properties.nearPlane);
 			cam.setFarPlane(camera.properties.farPlane);
 			cam.setFieldOfView(camera.properties.fieldOfView);
-		}
+		}*/
 		
 		return this;
 	}

--- a/src/rajawali/renderer/AFrameTask.java
+++ b/src/rajawali/renderer/AFrameTask.java
@@ -1,0 +1,104 @@
+/**
+ * 
+ */
+package rajawali.renderer;
+
+
+
+/**
+ * This is an abstract class to extend for things which need to have
+ * their addition/removal/modification in the scene properly regulated
+ * by the {@link RajawaliRenderer} and OpenGL thread. 
+ * 
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public abstract class AFrameTask {
+	
+	/**
+	 * Which task needs to be performed. Can be one of 
+	 * NONE, ADD, REMOVE, REMOVE_ALL or REPLACE.
+	 * 
+	 * <p>NONE - Do nothing. <br>
+	 * ADD - Adds an object to the related list. If an 
+	 * index is specified. <br>
+	 * ADD_ALL - Adds all objects from a collection to the
+	 * related list.<br>
+	 * REMOVE - Removes an object from the related list. 
+	 * If object is null, an index must be specified.<br>
+	 * REMOVE_ALL - Removes all objects from the related list, or
+	 * if a collection is specified, all the matching objects.<br>
+	 * REPLACE - Replaces an object in the related list 
+	 * at the specified index.</p>
+	 */
+	public enum TASK {NONE, ADD, ADD_ALL, REMOVE, REMOVE_ALL, REPLACE};
+	
+	/**
+	 * The type of object this task is acting on.
+	 */
+	public enum TYPE {ANIMATION, CAMERA, LIGHT, OBJECT3D, PLUGIN, TEXTURE, SCENE};
+	
+	private AFrameTask.TASK mFrameTask = AFrameTask.TASK.NONE; //The task to perform
+	private int mFrameTaskIndex = UNUSED_INDEX; //The index to replace, if relevant
+	private AFrameTask mNewObject; //The AFrameTask object to replace if used
+	
+	public static final int UNUSED_INDEX = -1;
+	
+	/**
+	 * Gets the type of object this task acts on.
+	 */
+	public abstract TYPE getFrameTaskType();
+	
+	/**
+	 * Retrieves the task to be performed.
+	 * 
+	 * @return {@link AFrameTask.TASK} to be performed.
+	 */
+	public AFrameTask.TASK getTask() {
+		return mFrameTask;
+	}
+	
+	/**
+	 * Sets the task to be performed.
+	 * 
+	 * @param task {@AFrameTask.TASK} to be performed.
+	 */
+	public void setTask(AFrameTask.TASK task) {
+		mFrameTask = task;
+	}
+	
+	/**
+	 * Gets the index this task acts on.
+	 * 
+	 * @return int The index.
+	 */
+	public int getIndex() {
+		return mFrameTaskIndex;
+	}
+	
+	/**
+	 * Sets the index this task acts on.
+	 * 
+	 * @param int The index.
+	 */
+	public void setIndex(int index) {
+		mFrameTaskIndex = index;
+	}
+	
+	/**
+	 * Gets the {@link AFrameTask} object this one replaces.
+	 * 
+	 * @return {@link AFrameTask} which needs to be replaced.
+	 */
+	public AFrameTask getNewObject() {
+		return mNewObject;
+	}
+	
+	/**
+	 * Sets the replacement.
+	 * 
+	 * @param object {@link AFrameTask} object which will replace this one.
+	 */
+	public void setNewObject(AFrameTask object) {
+		mNewObject = object;
+	}
+}

--- a/src/rajawali/renderer/EmptyTask.java
+++ b/src/rajawali/renderer/EmptyTask.java
@@ -1,0 +1,16 @@
+package rajawali.renderer;
+
+
+public final class EmptyTask extends AFrameTask {
+
+	private final AFrameTask.TYPE mType;
+	
+	public EmptyTask(AFrameTask.TYPE type) {
+		mType = type;
+	}
+
+	@Override
+	public AFrameTask.TYPE getFrameTaskType() {
+		return mType;
+	}
+}

--- a/src/rajawali/renderer/GroupTask.java
+++ b/src/rajawali/renderer/GroupTask.java
@@ -1,0 +1,29 @@
+package rajawali.renderer;
+
+import java.util.Collection;
+
+
+public final class GroupTask extends AFrameTask {
+
+	private final AFrameTask.TYPE mType;
+	private final Collection<AFrameTask> mCollection;
+	
+	public GroupTask(AFrameTask.TYPE type) {
+		mType = type;
+		mCollection = null;
+	}
+	
+	public GroupTask(Collection<AFrameTask> collection) {
+		mType = null;
+		mCollection = collection;
+	}
+	
+	@Override
+	public TYPE getFrameTaskType() {
+		return mType;
+	}
+
+	public Collection<AFrameTask> getCollection() {
+		return mCollection;
+	}
+}

--- a/src/rajawali/renderer/plugins/LensFlarePlugin.java
+++ b/src/rajawali/renderer/plugins/LensFlarePlugin.java
@@ -295,7 +295,7 @@ public final class LensFlarePlugin extends Plugin {
 		float halfViewportHeight = viewportHeight / 2;
 		Number3D screenPosition = new Number3D();
 		float screenPositionPixels_x, screenPositionPixels_y;
-		Camera camera = mRenderer.getCamera();
+		Camera camera = mRenderer.getCurrentScene().getCamera();
 		float[] viewMatrix = camera.getViewMatrix().clone(), projMatrix = camera.getProjectionMatrix().clone();
 		
 		useProgram(mProgram);

--- a/src/rajawali/renderer/plugins/Plugin.java
+++ b/src/rajawali/renderer/plugins/Plugin.java
@@ -3,17 +3,18 @@
  */
 package rajawali.renderer.plugins;
 
-import android.opengl.GLES20;
 import rajawali.Geometry3D;
+import rajawali.renderer.AFrameTask;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.RajLog;
+import android.opengl.GLES20;
 
 
 /**
  * Most plugins should generally inherit from this Plugin abstract class.
  * @author Andrew Jo
  */
-public abstract class Plugin implements IRendererPlugin {
+public abstract class Plugin extends AFrameTask implements IRendererPlugin {
 	protected Geometry3D mGeometry;
 	protected RajawaliRenderer mRenderer;
 	
@@ -147,5 +148,9 @@ public abstract class Plugin implements IRendererPlugin {
 		}
 		// Signal that we'll be using the shader program.
 		GLES20.glUseProgram(programHandle);
+	}
+	
+	public AFrameTask.TYPE getFrameTaskType() {
+		return AFrameTask.TYPE.PLUGIN;
 	}
 }

--- a/src/rajawali/scene/RajawaliScene.java
+++ b/src/rajawali/scene/RajawaliScene.java
@@ -1,0 +1,1483 @@
+package rajawali.scene;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import rajawali.BaseObject3D;
+import rajawali.Camera;
+import rajawali.animation.Animation3D;
+import rajawali.materials.SimpleMaterial;
+import rajawali.materials.SkyboxMaterial;
+import rajawali.materials.TextureInfo;
+import rajawali.math.Number3D;
+import rajawali.primitives.Cube;
+import rajawali.renderer.AFrameTask;
+import rajawali.renderer.EmptyTask;
+import rajawali.renderer.GroupTask;
+import rajawali.renderer.RajawaliRenderer;
+import rajawali.renderer.plugins.IRendererPlugin;
+import rajawali.scenegraph.IGraphNode;
+import rajawali.scenegraph.IGraphNode.GRAPH_TYPE;
+import rajawali.scenegraph.IGraphNodeMember;
+import rajawali.scenegraph.Octree;
+import rajawali.util.ObjectColorPicker.ColorPickerInfo;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+import android.opengl.GLES20;
+
+/**
+ * This is the container class for scenes in Rajawali.
+ * 
+ * It is intended that children, lights, cameras and animations
+ * will be added to this object and this object will be added
+ * to the {@link RajawaliRenderer} instance.
+ * 
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public class RajawaliScene extends AFrameTask {
+	
+	protected final int GL_COVERAGE_BUFFER_BIT_NV = 0x8000;
+	protected float mEyeZ = 4.0f;
+	
+	protected RajawaliRenderer mRenderer;
+	
+	protected float[] mVMatrix = new float[16];
+	protected float[] mPMatrix = new float[16];
+	
+	protected float mRed, mBlue, mGreen, mAlpha;
+	protected Cube mSkybox;
+	/**
+	* Temporary camera which will be switched to by the GL thread.
+	* Guarded by {@link #mNextSkyboxLock}
+	*/
+	private Cube mNextSkybox;
+	private final Object mNextSkyboxLock = new Object();
+	protected TextureInfo mSkyboxTextureInfo;
+	
+	protected ColorPickerInfo mPickerInfo;
+	protected boolean mReloadPickerInfo;
+	protected boolean mUsesCoverageAa;
+	protected boolean mEnableDepthBuffer = true;
+
+	private List<BaseObject3D> mChildren;
+	private List<Animation3D> mAnimations;
+	private List<IRendererPlugin> mPlugins;
+	
+	/**
+	* The camera currently in use.
+	* Not thread safe for speed, should
+	* only be used by GL thread (onDrawFrame() and render())
+	* or prior to rendering such as initScene(). 
+	*/
+	protected Camera mCamera;
+	private List<Camera> mCameras; //List of all cameras in the scene.
+	/**
+	* Temporary camera which will be switched to by the GL thread.
+	* Guarded by {@link #mNextCameraLock}
+	*/
+	private Camera mNextCamera;
+	private final Object mNextCameraLock = new Object();
+	
+	/**
+	 * Frame task queue. Adding, removing or replacing members
+	 * such as children, cameras, plugins, etc is now prohibited
+	 * outside the use of this queue. The render thread will automatically
+	 * handle the necessary operations at an appropriate time, ensuring 
+	 * thread safety and general correct operation.
+	 * 
+	 * Guarded by itself
+	 */
+	private LinkedList<AFrameTask> mFrameTaskQueue;
+
+	protected boolean mDisplaySceneGraph = false;
+	protected IGraphNode mSceneGraph; //The scenegraph for this scene
+	protected GRAPH_TYPE mSceneGraphType = GRAPH_TYPE.NONE; //The type of graph type for this scene.
+	
+	public RajawaliScene(RajawaliRenderer renderer) {
+		mRenderer = renderer;
+		mAlpha = 0;
+		mAnimations = Collections.synchronizedList(new CopyOnWriteArrayList<Animation3D>());
+		mChildren = Collections.synchronizedList(new CopyOnWriteArrayList<BaseObject3D>());
+		mPlugins = Collections.synchronizedList(new CopyOnWriteArrayList<IRendererPlugin>());
+		mCameras = Collections.synchronizedList(new CopyOnWriteArrayList<Camera>());
+		mFrameTaskQueue = new LinkedList<AFrameTask>();
+		
+		mCamera = new Camera();
+		mCamera.setZ(mEyeZ);
+		mCameras = Collections.synchronizedList(new CopyOnWriteArrayList<Camera>());
+		mCameras.add(mCamera);
+	}
+	
+	public RajawaliScene(RajawaliRenderer renderer, GRAPH_TYPE type) {
+		this(renderer);
+		mSceneGraphType = type;
+		initSceneGraph();
+	}
+	
+	/**
+	 * Automatically creates the specified scene graph type with that graph's default
+	 * behavior. If you want to use a specific constructor you will need to override this
+	 * method. 
+	 */
+	protected void initSceneGraph() {
+		switch (mSceneGraphType) { //Contrived with only one type I know. For the future!
+		case OCTREE:
+			mSceneGraph = new Octree();
+			break;
+		default:
+			break;
+		}
+	}
+	
+	/**
+	 * Fetch the minimum bounds of the scene.
+	 * 
+	 * @return {@link Number3D} containing the minimum values along each axis.
+	 */
+	public Number3D getSceneMinBound() {
+		if (mSceneGraph != null) {
+			return mSceneGraph.getSceneMinBound();
+		} else {
+			return new Number3D(Float.MIN_VALUE, Float.MIN_VALUE, Float.MIN_VALUE);
+		}
+	}
+	
+	/**
+	 * Fetch the maximum bounds of the scene.
+	 * 
+	 * @return {@link Number3D} containing the maximum values along each axis.
+	 */
+	public Number3D getSceneMaxBound() {
+		if (mSceneGraph != null) {
+			return mSceneGraph.getSceneMaxBound();
+		} else {
+			return new Number3D(Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
+		}
+	}
+	
+	/**
+	* Switches the {@link Camera} currently being used to display the scene.
+	* 
+	* @param mCamera {@link Camera} object to display the scene with.
+	*/
+	public void switchCamera(Camera camera) {
+		synchronized (mNextCameraLock) {
+			mNextCamera = camera;
+		}
+	}
+
+	/**
+	* Switches the {@link Camera} currently being used to display the scene.
+	* 
+	* @param camera Index of the {@link Camera} to use.
+	*/
+	public void switchCamera(int camera) {
+		switchCamera(mCameras.get(camera));
+	}
+
+	/**
+	* Fetches the {@link Camera} currently being used to display the scene.
+	* Note that the camera is not thread safe so this should be used
+	* with extreme caution.
+	* 
+	* @return {@link Camera} object currently used for the scene.
+	* @see {@link RajawaliRenderer#mCamera}
+	*/
+	public Camera getCamera() {
+		return this.mCamera;
+	}
+
+	/**
+	* Fetches the specified {@link Camera}. 
+	* 
+	* @param camera Index of the {@link Camera} to fetch.
+	* @return Camera which was retrieved.
+	*/
+	public Camera getCamera(int camera) {
+		return mCameras.get(camera);
+	}
+
+	/**
+	* Adds a {@link Camera} to the scene.
+	* 
+	* @param camera {@link Camera} object to add.
+	* @return boolean True if the addition was successfully queued.
+	*/
+	public boolean addCamera(Camera camera) {
+		return queueAddTask(camera);
+	}
+	
+	/**
+	 * Adds a {@link Collection} of {@link Camera} objects to the scene.
+	 * 
+	 * @param cameras {@link Collection} of {@link Camera} objects to add.
+	 * @return boolean True if the addition was successfully queued.
+	 */
+	public boolean addCameras(Collection<Camera> cameras) {
+		ArrayList<AFrameTask> tasks = new ArrayList<AFrameTask>(cameras);
+		return queueAddAllTask(tasks);
+	}
+	
+	/**
+	 * Removes a {@link Camera} from the scene. If the {@link Camera}
+	 * being removed is the one in current use, the 0 index {@link Camera}
+	 * will be selected on the next frame.
+	 * 
+	 * @param camera {@link Camera} object to remove.
+	 * @return boolean True if the removal was successfully queued.
+	 */
+	public boolean removeCamera(Camera camera) {
+		return queueRemoveTask(camera);
+	}
+
+	/**
+	* Replaces a {@link Camera} in the renderer at the specified location
+	* in the list. This does not validate the index, so if it is not
+	* contained in the list already, an exception will be thrown.
+	* 
+	* If the {@link Camera} being replaced is the one in current use, 
+	* the replacement will be selected on the next frame.
+	* 
+	* @param camera {@link Camera} object to add.
+	* @param location Integer index of the camera to replace.
+	* @param boolean True if the replacement was successfully queued.
+	*/
+	public boolean replaceCamera(Camera camera, int location) {
+		return queueReplaceTask(location, camera);
+	}
+	
+	/**
+	* Replaces the specified {@link Camera} in the renderer with the
+	* provided {@link Camera}. If the {@link Camera} being replaced is
+	* the one in current use, the replacement will be selected on the next
+	* frame.
+	* 
+	* @param oldCamera {@link Camera} object to be replaced.
+	* @param newCamera {@link Camera} object replacing the old.
+	* @param boolean True if the replacement was successfully queued.
+	*/
+	public boolean replaceCamera(Camera oldCamera, Camera newCamera) {
+		return queueReplaceTask(oldCamera, newCamera);
+	}
+
+	/**
+	* Adds a {@link Camera}, switching to it immediately.
+	* 
+	* @param camera The {@link Camera} to add.
+	* @return boolean True if the addition was successfully queued.
+	*/
+	public boolean addAndSwitchCamera(Camera camera) {
+		boolean success = addCamera(camera);
+		switchCamera(camera);
+		return success;
+	}
+
+	/**
+	* Replaces a {@link Camera} at the specified index with an option to switch to it
+	* immediately.
+	* 
+	* @param camera The {@link Camera} to add.
+	* @param location The index of the camera to replace.
+	* @return boolean True if the replacement was successfully queued.
+	*/
+	public boolean replaceAndSwitchCamera(Camera camera, int location) {
+		boolean success = replaceCamera(camera, location);
+		switchCamera(camera);
+		return success;
+	}
+	
+	/**
+	* Replaces the specified {@link Camera} in the renderer with the
+	* provided {@link Camera}, switching immediately.
+	* 
+	* @param oldCamera {@link Camera} object to be replaced.
+	* @param newCamera {@link Camera} object replacing the old.
+	* @param boolean True if the replacement was successfully queued.
+	*/
+	public boolean replaceAndSwitchCamera(Camera oldCamera, Camera newCamera) {
+		boolean success = queueReplaceTask(oldCamera, newCamera);
+		switchCamera(newCamera);
+		return success;
+	}
+	
+	/**
+	 * Replaces a {@link BaseObject3D} at the specified index with a new one.
+	 * 
+	 * @param child {@link BaseObject3D} the new child.
+	 * @param location The index of the child to replace.
+	 * @return boolean True if the replacement was successfully queued.
+	 */
+	public boolean replaceChild(BaseObject3D child, int location) {
+		return queueReplaceTask(location, child);
+	}
+	
+	/**
+	 * Replaces a specified {@link BaseObject3D} with a new one.
+	 * 
+	 * @param oldChild {@link BaseObject3D} the old child.
+	 * @param newChild {@link BaseObject3D} the new child.
+	 * @return boolean True if the replacement was successfully queued.
+	 */
+	public boolean replaceChild(BaseObject3D oldChild, BaseObject3D newChild) {
+		return queueReplaceTask(oldChild, newChild);
+	}
+	
+	/**
+	 * Requests the addition of a child to the scene. The child
+	 * will be added to the end of the list. 
+	 * 
+	 * @param child {@link BaseObject3D} child to be added.
+	 * @return True if the child was successfully queued for addition.
+	 */
+	public boolean addChild(BaseObject3D child) {
+		return queueAddTask(child);
+	}
+	
+	/**
+	 * Requests the addition of a {@link Collection} of children to the scene.
+	 * 
+	 * @param children {@link Collection} of {@link BaseObject3D} children to add.
+	 * @return boolean True if the addition was successfully queued.
+	 */
+	public boolean addChildren(Collection<BaseObject3D> children) {
+		ArrayList<AFrameTask> tasks = new ArrayList<AFrameTask>(children);
+		return queueAddAllTask(tasks);
+	}
+	
+	/**
+	 * Requests the removal of a child from the scene.
+	 * 
+	 * @param child {@link BaseObject3D} child to be removed.
+	 * @return boolean True if the child was successfully queued for removal.
+	 */
+	public boolean removeChild(BaseObject3D child) {
+		return queueRemoveTask(child);
+	}
+	
+	/**
+	 * Requests the removal of all children from the scene.
+	 * 
+	 * @return boolean True if the clear was successfully queued.
+	 */
+	public boolean clearChildren() {
+		return queueClearTask(AFrameTask.TYPE.OBJECT3D);
+	}
+	
+	/**
+	 * Register an animation to be managed by the scene. This is optional 
+	 * leaving open the possibility to manage updates on Animations in your own implementation.
+	 * 
+	 * @param anim {@link Animation3D} to be registered.
+	 * @return boolean True if the registration was queued successfully.
+	 */
+	public boolean registerAnimation(Animation3D anim) {
+		return queueAddTask(anim);
+	}
+	
+	/**
+	 * Remove a managed animation. If the animation is not a member of the scene, 
+	 * nothing will happen.
+	 * 
+	 * @param anim {@link Animation3D} to be unregistered.
+	 * @return boolean True if the unregister was queued successfully.
+	 */
+	public boolean unregisterAnimation(Animation3D anim) {
+		return queueRemoveTask(anim);
+	}
+	
+	/**
+	 * Replace an {@link Animation3D} with a new one.
+	 * 
+	 * @param oldAnim {@link Animation3D} the old animation.
+	 * @param newAnim {@link Animation3D} the new animation.
+	 * @return boolean True if the replacement task was queued successfully.
+	 */
+	public boolean replaceAnimation(Animation3D oldAnim, Animation3D newAnim) {
+		return queueReplaceTask(oldAnim, newAnim);
+	}
+	
+	/**
+	 * Adds a {@link Collection} of {@link Animation3D} objects to the scene.
+	 * 
+	 * @param anims {@link Collection} containing the {@link Animation3D} objects to be added.
+	 * @return boolean True if the addition was queued successfully.
+	 */
+	public boolean registerAnimations(Collection<Animation3D> anims) {
+		ArrayList<AFrameTask> tasks = new ArrayList<AFrameTask>(anims);
+		return queueAddAllTask(tasks);
+	}
+	
+	/**
+	 * Removes all {@link Animation3D} objects from the scene.
+	 * 
+	 * @return boolean True if the clear task was queued successfully.
+	 */
+	public boolean clearAnimations() {
+		return queueClearTask(AFrameTask.TYPE.ANIMATION);
+	}
+	
+	/**
+	 * Creates a skybox with the specified single texture.
+	 * 
+	 * @param resourceId int Resouce id of the skybox texture.
+	 */
+	public void setSkybox(int resourceId) {
+		synchronized (mCameras) {
+			for (int i = 0, j = mCameras.size(); i < j; ++i)
+				mCameras.get(i).setFarPlane(1000);
+		}
+		synchronized (mNextSkyboxLock) {
+			mNextSkybox = new Cube(700, true, false);
+			mNextSkybox.setDoubleSided(true);
+			mSkyboxTextureInfo = mRenderer.getTextureManager().addTexture(BitmapFactory.decodeResource(
+					mRenderer.getContext().getResources(), resourceId));
+			SimpleMaterial material = new SimpleMaterial();
+			material.addTexture(mSkyboxTextureInfo);
+			mNextSkybox.setMaterial(material);
+		}
+	}
+
+	/**
+	 * Creates a skybox with the specified 6 textures. 
+	 * 
+	 * @param front int Resource id for the front face.
+	 * @param right int Resource id for the right face.
+	 * @param back int Resource id for the back face.
+	 * @param left int Resource id for the left face.
+	 * @param up int Resource id for the up face.
+	 * @param down int Resource id for the down face.
+	 */
+	public void setSkybox(int front, int right, int back, int left, int up, int down) {
+		synchronized (mCameras) {
+			for (int i = 0, j = mCameras.size(); i < j; ++i)
+				mCameras.get(i).setFarPlane(1000);
+		}
+		synchronized (mNextSkyboxLock) {
+			mNextSkybox = new Cube(700, true);
+			Context context = mRenderer.getContext();
+			Bitmap[] textures = new Bitmap[6];
+			textures[0] = BitmapFactory.decodeResource(context.getResources(), left);
+			textures[1] = BitmapFactory.decodeResource(context.getResources(), right);
+			textures[2] = BitmapFactory.decodeResource(context.getResources(), up);
+			textures[3] = BitmapFactory.decodeResource(context.getResources(), down);
+			textures[4] = BitmapFactory.decodeResource(context.getResources(), front);
+			textures[5] = BitmapFactory.decodeResource(context.getResources(), back);
+
+			mSkyboxTextureInfo = mRenderer.getTextureManager().addCubemapTextures(textures);
+			SkyboxMaterial mat = new SkyboxMaterial();
+			mat.addTexture(mSkyboxTextureInfo);
+			mNextSkybox.setMaterial(mat);
+		}
+	}
+	
+	/**
+	 * Updates the sky box textures with a single texture. 
+	 * 
+	 * @param resourceId int the resource id of the new texture.
+	 */
+	public void updateSkybox(int resourceId) {
+		mRenderer.getTextureManager().updateTexture(mSkyboxTextureInfo, BitmapFactory.decodeResource(
+				mRenderer.getContext().getResources(), resourceId));
+	}
+	
+	/**
+	 * Updates the sky box textures with 6 new resource ids. 
+	 * 
+	 * @param front int Resource id for the front face.
+	 * @param right int Resource id for the right face.
+	 * @param back int Resource id for the back face.
+	 * @param left int Resource id for the left face.
+	 * @param up int Resource id for the up face.
+	 * @param down int Resource id for the down face.
+	 */
+	public void updateSkybox(int front, int right, int back, int left, int up, int down) {
+		Context context = mRenderer.getContext();
+		Bitmap[] textures = new Bitmap[6];
+		textures[0] = BitmapFactory.decodeResource(context.getResources(), left);
+		textures[1] = BitmapFactory.decodeResource(context.getResources(), right);
+		textures[2] = BitmapFactory.decodeResource(context.getResources(), up);
+		textures[3] = BitmapFactory.decodeResource(context.getResources(), down);
+		textures[4] = BitmapFactory.decodeResource(context.getResources(), front);
+		textures[5] = BitmapFactory.decodeResource(context.getResources(), back);
+
+		mRenderer.getTextureManager().updateCubemapTextures(mSkyboxTextureInfo, textures);
+	}
+	
+	public void requestColorPickingTexture(ColorPickerInfo pickerInfo) {
+		mPickerInfo = pickerInfo;
+	}
+	
+	/**
+	 * Reloads this scene.
+	 */
+	public void reload() {
+		reloadChildren();
+		if(mSkybox != null)
+			mSkybox.reload();
+		reloadPlugins();
+		mReloadPickerInfo = true;
+	}
+	
+	/**
+	 * Clears the scene of contents. Note that this is NOT the same as destroying the scene.
+	 */
+	public void clear() {
+		if (mChildren.size() > 0) {
+			queueClearTask(AFrameTask.TYPE.OBJECT3D);
+		}
+		if (mPlugins.size() > 0) {
+			queueClearTask(AFrameTask.TYPE.PLUGIN);
+		}
+	}
+	
+	/**
+	 * Is the object picking info?
+	 * 
+	 * @return boolean True if object picking is active.
+	 */
+	public boolean hasPickerInfo() {
+		return (mPickerInfo != null);
+	}
+	
+	public void render(double deltaTime) {
+		performFrameTasks(); //Handle the task queue
+		synchronized (mNextSkyboxLock) {
+			//Check if we need to switch the skybox, and if so, do it.
+			if (mNextSkybox != null) {
+				mSkybox = mNextSkybox;
+				mNextSkybox = null;
+			}
+		}
+		synchronized (mNextCameraLock) { 
+			//Check if we need to switch the camera, and if so, do it.
+			if (mNextCamera != null) {
+				mCamera = mNextCamera;
+				mNextCamera = null;
+				mCamera.setProjectionMatrix(mRenderer.getViewportWidth(), mRenderer.getViewportHeight());
+			}
+		}
+		
+		int clearMask = GLES20.GL_COLOR_BUFFER_BIT;
+
+		ColorPickerInfo pickerInfo = mPickerInfo;
+
+		if (pickerInfo != null) {
+			if(mReloadPickerInfo) pickerInfo.getPicker().reload();
+			mReloadPickerInfo = false;
+			pickerInfo.getPicker().bindFrameBuffer();
+			GLES20.glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
+		} else {
+			GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0);
+			GLES20.glClearColor(mRed, mGreen, mBlue, mAlpha);
+		}
+
+		if (mEnableDepthBuffer) {
+			clearMask |= GLES20.GL_DEPTH_BUFFER_BIT;
+			GLES20.glEnable(GLES20.GL_DEPTH_TEST);
+			GLES20.glDepthFunc(GLES20.GL_LESS);
+			GLES20.glDepthMask(true);
+			GLES20.glClearDepthf(1.0f);
+		}
+		if (mUsesCoverageAa) {
+			clearMask |= GL_COVERAGE_BUFFER_BIT_NV;
+		}
+
+		GLES20.glClear(clearMask);
+
+		mVMatrix = mCamera.getViewMatrix();
+		mPMatrix = mCamera.getProjectionMatrix();
+
+		if (mSkybox != null) {
+			GLES20.glDisable(GLES20.GL_DEPTH_TEST);
+			GLES20.glDepthMask(false);
+
+			mSkybox.setPosition(mCamera.getX(), mCamera.getY(), mCamera.getZ());
+			mSkybox.render(mCamera, mPMatrix, mVMatrix, pickerInfo);
+
+			if (mEnableDepthBuffer) {
+				GLES20.glEnable(GLES20.GL_DEPTH_TEST);
+				GLES20.glDepthMask(true);
+			}
+		}
+
+		mCamera.updateFrustum(mPMatrix, mVMatrix); //update frustum plane
+		
+		// Update all registered animations
+		synchronized (mAnimations) {
+			for (int i = 0, j = mAnimations.size(); i < j; ++i) {
+				Animation3D anim = mAnimations.get(i);
+				if (anim.isPlaying())
+					anim.update(deltaTime);
+			}
+		}
+
+		synchronized (mChildren) {
+			for (int i = 0, j = mChildren.size(); i < j; ++i) 
+				mChildren.get(i).render(mCamera, mPMatrix, mVMatrix, pickerInfo);
+		}
+
+		if (mDisplaySceneGraph) {
+			mSceneGraph.displayGraph(mCamera, mPMatrix, mVMatrix);
+        }
+		
+		if (pickerInfo != null) {
+			pickerInfo.getPicker().createColorPickingTexture(pickerInfo);
+			pickerInfo.getPicker().unbindFrameBuffer();
+			pickerInfo = null;
+			mPickerInfo = null;
+			render(deltaTime); //TODO Possible timing error here
+		}
+
+		synchronized (mPlugins) {
+			for (int i = 0, j = mPlugins.size(); i < j; i++)
+				mPlugins.get(i).render();
+		}
+	}
+	
+	/**
+	 * Queue an addition task. The added object will be placed
+	 * at the end of the renderer's list.
+	 * 
+	 * @param task {@link AFrameTask} to be added.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	public boolean queueAddTask(AFrameTask task) {
+		task.setTask(AFrameTask.TASK.ADD);
+		task.setIndex(AFrameTask.UNUSED_INDEX);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue an addition task. The added object will be placed
+	 * at the specified index in the renderer's list, or the end
+	 * if out of range. 
+	 * 
+	 * @param task {@link AFrameTask} to be added.
+	 * @param index Integer index to place the object at.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	public boolean queueAddTask(AFrameTask task, int index) {
+		task.setTask(AFrameTask.TASK.ADD);
+		task.setIndex(index);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue a removal task. The removal will occur at the specified
+	 * index, or at the end of the list if out of range.
+	 * 
+	 * @param type {@link AFrameTask.TYPE} Which list to remove from.
+	 * @param index Integer index to remove the object at.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	protected boolean queueRemoveTask(AFrameTask.TYPE type, int index) {
+		EmptyTask task = new EmptyTask(type);
+		task.setTask(AFrameTask.TASK.REMOVE);
+		task.setIndex(index);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue a removal task to remove the specified object.
+	 * 
+	 * @param task {@link AFrameTask} to be removed.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	protected boolean queueRemoveTask(AFrameTask task) {
+		task.setTask(AFrameTask.TASK.REMOVE);
+		task.setIndex(AFrameTask.UNUSED_INDEX);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue a replacement task to replace the object at the
+	 * specified index with a new one. Replaces the object at
+	 * the end of the list if index is out of range.
+	 * 
+	 * @param index Integer index of the object to replace.
+	 * @param replacement {@link AFrameTask} the object replacing the old.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	protected boolean queueReplaceTask(int index, AFrameTask replacement) {
+		EmptyTask task = new EmptyTask(replacement.getFrameTaskType());
+		task.setTask(AFrameTask.TASK.REPLACE);
+		task.setIndex(index);
+		task.setNewObject(replacement);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue a replacement task to replace the specified object with the new one.
+	 * 
+	 * @param task {@link AFrameTask} the object to replace.
+	 * @param replacement {@link AFrameTask} the object replacing the old.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	protected boolean queueReplaceTask(AFrameTask task, AFrameTask replacement) {
+		task.setTask(AFrameTask.TASK.REPLACE);
+		task.setIndex(AFrameTask.UNUSED_INDEX);
+		task.setNewObject(replacement);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue an add all task to add all objects from the given collection.
+	 * 
+	 * @param collection {@link Collection} containing all the objects to add.
+	 * @return boolean True if the task was successfully queued. 
+	 */
+	protected boolean queueAddAllTask(Collection<AFrameTask> collection) {
+		GroupTask task = new GroupTask(collection);
+		task.setTask(AFrameTask.TASK.ADD_ALL);
+		task.setIndex(AFrameTask.UNUSED_INDEX);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue a remove all task which will clear the related list.
+	 * 
+	 * @param type {@link AFrameTask.TYPE} Which object list to clear (Cameras, BaseObject3D, etc)
+	 * @return boolean True if the task was successfully queued.
+	 */
+	protected boolean queueClearTask(AFrameTask.TYPE type) {
+		GroupTask task = new GroupTask(type);
+		task.setTask(AFrameTask.TASK.REMOVE_ALL);
+		task.setIndex(AFrameTask.UNUSED_INDEX);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Queue a remove all task which will remove all objects from the given collection
+	 * from the related list.
+	 * 
+	 * @param collection {@link Collection} containing all the objects to be removed.
+	 * @return boolean True if the task was successfully queued.
+	 */
+	protected boolean queueRemoveAllTask(Collection<AFrameTask> collection) { 
+		GroupTask task = new GroupTask(collection);
+		task.setTask(AFrameTask.TASK.REMOVE_ALL);
+		task.setIndex(AFrameTask.UNUSED_INDEX);
+		return addTaskToQueue(task);
+	}
+	
+	/**
+	 * Adds a task to the frame task queue.
+	 * 
+	 * @param task AFrameTask to be added.
+	 * @return boolean True on successful addition to queue.
+	 */
+	private boolean addTaskToQueue(AFrameTask task) {
+		synchronized (mFrameTaskQueue) {
+			return mFrameTaskQueue.offer(task);
+		}
+	}
+	
+	/**
+	 * Internal method for performing frame tasks. Should be called at the
+	 * start of onDrawFrame() prior to render().
+	 */
+	private void performFrameTasks() {
+		synchronized (mFrameTaskQueue) {
+			//Fetch the first task
+			AFrameTask taskObject = mFrameTaskQueue.poll();
+			while (taskObject != null) {
+				AFrameTask.TASK task = taskObject.getTask();
+				switch (task) {
+				case NONE:
+					//DO NOTHING
+					return;
+				case ADD:
+					handleAddTask(taskObject);
+					break;
+				case ADD_ALL:
+					handleAddAllTask(taskObject);
+					break;
+				case REMOVE:
+					handleRemoveTask(taskObject);
+					break;
+				case REMOVE_ALL:
+					handleRemoveAllTask(taskObject);
+					break;
+				case REPLACE:
+					handleReplaceTask(taskObject);
+					break;
+				}
+				//Retrieve the next task
+				taskObject = mFrameTaskQueue.poll();
+			}
+		}
+	}
+	
+	/**
+	 * Internal method for handling replacement tasks.
+	 * 
+	 * @param task {@link AFrameTask} object to process.
+	 */
+	private void handleReplaceTask(AFrameTask task) {
+		AFrameTask.TYPE type = task.getFrameTaskType();
+		switch (type) {
+		case ANIMATION:
+			internalReplaceAnimation(task, (Animation3D) task.getNewObject(), task.getIndex());
+			break;
+		case CAMERA:
+			internalReplaceCamera(task, (Camera) task.getNewObject(), task.getIndex());
+			break;
+		case LIGHT:
+			//TODO: Handle light replacement
+			break;
+		case OBJECT3D:
+			internalReplaceChild(task, (BaseObject3D) task.getNewObject(), task.getIndex());
+			break;
+		case PLUGIN:
+			internalReplacePlugin(task, (IRendererPlugin) task.getNewObject(), task.getIndex());
+			break;
+		case TEXTURE:
+			//TODO: Handle texture replacement
+			break;
+		default:
+			break;
+		}
+	}
+
+	/**
+	 * Internal method for handling addition tasks.
+	 * 
+	 * @param task {@link AFrameTask} object to process.
+	 */
+	private void handleAddTask(AFrameTask task) {
+		AFrameTask.TYPE type = task.getFrameTaskType();
+		switch (type) {
+		case ANIMATION:
+			internalAddAnimation((Animation3D) task, task.getIndex());
+			break;
+		case CAMERA:
+			internalAddCamera((Camera) task, task.getIndex());
+			break;
+		case LIGHT:
+			//TODO: Handle light addition
+			break;
+		case OBJECT3D:
+			internalAddChild((BaseObject3D) task, task.getIndex());
+			break;
+		case PLUGIN:
+			internalAddPlugin((IRendererPlugin) task, task.getIndex());
+			break;
+		case TEXTURE:
+			//TODO: Handle texture addition
+			break;
+		default:
+			break;
+		}
+	}
+	
+	/**
+	 * Internal method for handling removal tasks.
+	 * 
+	 * @param task {@link AFrameTask} object to process.
+	 */
+	private void handleRemoveTask(AFrameTask task) {
+		AFrameTask.TYPE type = task.getFrameTaskType();
+		switch (type) {
+		case ANIMATION:
+			internalRemoveAnimation((Animation3D) task, task.getIndex());
+			break;
+		case CAMERA:
+			internalRemoveCamera((Camera) task, task.getIndex());
+			break;
+		case LIGHT:
+			//TODO: Handle light removal
+			break;
+		case OBJECT3D:
+			internalRemoveChild((BaseObject3D) task, task.getIndex());
+			break;
+		case PLUGIN:
+			internalRemovePlugin((IRendererPlugin) task, task.getIndex());
+			break;
+		case TEXTURE:
+			//TODO: Handle texture removal
+			break;
+		default:
+			break;
+		}
+	}
+	
+	/**
+	 * Internal method for handling add all tasks.
+	 * 
+	 * @param task {@link AFrameTask} object to process.
+	 */
+	private void handleAddAllTask(AFrameTask task) {
+		GroupTask group = (GroupTask) task;
+		AFrameTask[] tasks = (AFrameTask[]) group.getCollection().toArray();
+		AFrameTask.TYPE type = tasks[0].getFrameTaskType();
+		int i = 0;
+		int j = tasks.length;
+		switch (type) {
+		case ANIMATION:
+			for (i = 0; i < j; ++i) {
+				internalAddAnimation((Animation3D) tasks[i], AFrameTask.UNUSED_INDEX);
+			}
+			break;
+		case CAMERA:
+			for (i = 0; i < j; ++i) {
+				internalAddCamera((Camera) tasks[i], AFrameTask.UNUSED_INDEX);
+			}
+			break;
+		case LIGHT:
+			//TODO: Handle light remove all
+			break;
+		case OBJECT3D:
+			for (i = 0; i < j; ++i) {
+				internalAddChild((BaseObject3D) tasks[i], AFrameTask.UNUSED_INDEX);
+			}
+			break;
+		case PLUGIN:
+			for (i = 0; i < j; ++i) {
+				internalAddPlugin((IRendererPlugin) tasks[i], AFrameTask.UNUSED_INDEX);
+			}
+			break;
+		case TEXTURE:
+			//TODO: Handle texture remove all
+			break;
+		default:
+			break;
+		}
+	}
+	
+	/**
+	 * Internal method for handling remove all tasks.
+	 * 
+	 * @param task {@link AFrameTask} object to process.
+	 */
+	private void handleRemoveAllTask(AFrameTask task) {
+		GroupTask group = (GroupTask) task;
+		AFrameTask.TYPE type = group.getFrameTaskType();
+		boolean clear = false;
+		AFrameTask[] tasks = null;
+		int i = 0, j = 0;
+		if (type == null) {
+			clear = true;
+		} else {
+			tasks = (AFrameTask[]) group.getCollection().toArray();
+			type = tasks[0].getFrameTaskType();
+			j = tasks.length;
+		}
+		switch (type) {
+		case ANIMATION:
+			if (clear) {
+				internalClearAnimations();
+			} else {
+				for (i = 0; i < j; ++i) {
+					internalRemoveAnimation((Animation3D) tasks[i], AFrameTask.UNUSED_INDEX);
+				}
+			}
+			break;
+		case CAMERA:
+			if (clear) {
+				internalClearCameras();
+			} else {
+				for (i = 0; i < j; ++i) {
+					internalRemoveCamera((Camera) tasks[i], AFrameTask.UNUSED_INDEX);
+				}
+			}
+			break;
+		case LIGHT:
+			//TODO: Handle light add all
+			break;
+		case OBJECT3D:
+			if (clear) {
+				internalClearChildren();
+			} else {
+				for (i = 0; i < j; ++i) {
+					internalAddChild((BaseObject3D) tasks[i], AFrameTask.UNUSED_INDEX);
+				}
+			}
+			break;
+		case PLUGIN:
+			if (clear) {
+				internalClearPlugins();
+			} else {
+				for (i = 0; i < j; ++i) {
+					internalAddPlugin((IRendererPlugin) tasks[i], AFrameTask.UNUSED_INDEX);
+				}
+			}
+			break;
+		case TEXTURE:
+			//TODO: Handle texture add all
+			break;
+		default:
+			break;
+		}
+	}
+	
+	/**
+	 * Internal method for replacing a {@link Animation3D} object. If index is
+	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * object is used. Should only be called through {@link #handleAddTask(AFrameTask)}
+	 * 
+	 * @param anim {@link AFrameTask} The old animation.
+	 * @param replace {@link Animation3D} The animation replacing the old animation.
+	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 */
+	private void internalReplaceAnimation(AFrameTask anim, Animation3D replace, int index) {
+		if (index != AFrameTask.UNUSED_INDEX) {
+			mAnimations.set(index, replace);
+		} else {
+			mAnimations.set(mAnimations.indexOf(anim), replace);
+		}
+	}
+	
+	/**
+	 * Internal method for adding {@link Animation3D} objects.
+	 * Should only be called through {@link #handleAddTask(AFrameTask)}
+	 * 
+	 * This takes an index for the addition, but it is pretty
+	 * meaningless.
+	 * 
+	 * @param anim {@link Animation3D} to add.
+	 * @param int index to add the animation at. 
+	 */
+	private void internalAddAnimation(Animation3D anim, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mAnimations.add(anim);
+		} else {
+			mAnimations.add(index, anim);
+		}
+	}
+	
+	/**
+	 * Internal method for removing {@link Animation3D} objects.
+	 * Should only be called through {@link #handleRemoveTask(AFrameTask)}
+	 * 
+	 * This takes an index for the removal. 
+	 * 
+	 * @param anim {@link Animation3D} to remove. If index is used, this is ignored.
+	 * @param index integer index to remove the child at. 
+	 */
+	private void internalRemoveAnimation(Animation3D anim, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mAnimations.remove(anim);
+		} else {
+			mAnimations.remove(index);
+		}
+	}
+	
+	/**
+	 * Internal method for removing all {@link Animation3D} objects.
+	 * Should only be called through {@link #handleRemoveAllTask(AFrameTask)}
+	 */
+	private void internalClearAnimations() {
+		mAnimations.clear();
+	}
+	
+	/**
+	 * Internal method for replacing a {@link Camera}. If index is
+	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
+	 * 
+	 * @param camera {@link Camera} The old camera.
+	 * @param replace {@link Camera} The camera replacing the old camera.
+	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 */
+	private void internalReplaceCamera(AFrameTask camera, Camera replace, int index) {
+		if (index != AFrameTask.UNUSED_INDEX) {
+			mCameras.set(index, replace);
+		} else {
+			mCameras.set(mCameras.indexOf(camera), replace);
+		}
+		//TODO: Handle camera replacement in scenegraph
+	}
+	
+	/**
+	 * Internal method for adding a {@link Camera}.
+	 * Should only be called through {@link #handleAddTask(AFrameTask)}
+	 * 
+	 * This takes an index for the addition, but it is pretty
+	 * meaningless.
+	 * 
+	 * @param camera {@link Camera} to add.
+	 * @param int index to add the camera at. 
+	 */
+	private void internalAddCamera(Camera camera, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mCameras.add(camera);
+		} else {
+			mCameras.add(index, camera);
+		}
+		if (mSceneGraph != null) {
+			//mSceneGraph.addObject(camera); //TODO: Uncomment
+		}
+	}
+	
+	/**
+	 * Internal method for removing a {@link Camera}.
+	 * Should only be called through {@link #handleRemoveTask(AFrameTask)}
+	 * 
+	 * This takes an index for the removal. 
+	 * 
+	 * NOTE: If there is only one camera and it is removed, bad things
+	 * will happen.
+	 * 
+	 * @param camera {@link Camera} to remove. If index is used, this is ignored.
+	 * @param index integer index to remove the camera at. 
+	 */
+	private void internalRemoveCamera(Camera camera, int index) {
+		Camera cam = camera;
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mCameras.remove(camera);
+		} else {
+			cam = mCameras.remove(index);
+		}
+		if (mCamera.equals(cam)) {
+			//If the current camera is the one being removed,
+			//switch to the new 0 index camera.
+			mCamera = mCameras.get(0);
+		}
+		if (mSceneGraph != null) {
+			//mSceneGraph.removeObject(camera); //TODO: Uncomment
+		}
+	}
+	
+	/**
+	 * Internal method for removing all {@link Camera} from the camera list.
+	 * Should only be called through {@link #handleRemoveAllTask(AFrameTask)}
+	 * Note that this will re-add the current camera.
+	 */
+	private void internalClearCameras() {
+		if (mSceneGraph != null) {
+			//mSceneGraph.removeAll(mCameras); //TODO: Uncomment
+		}
+		mCameras.clear();
+		mCameras.add(mCamera);
+	}	
+	
+	/**
+	 * Creates a shallow copy of the internal cameras list. 
+	 * 
+	 * @return ArrayList containing the cameras.
+	 */
+	public ArrayList<Camera> getCamerasCopy() {
+		ArrayList<Camera> list = new ArrayList<Camera>();
+		list.addAll(mCameras);
+		return list;
+	}
+	
+	/**
+	 * Retrieve the number of cameras.
+	 * 
+	 * @return The current number of cameras.
+	 */
+	public int getNumCameras() {
+		//Thread safety deferred to the List
+		return mCameras.size();
+	}
+	
+	/**
+	 * Internal method for replacing a {@link BaseObject3D} child. If index is
+	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
+	 * 
+	 * @param child {@link BaseObject3D} The new child for the specified index.
+	 * @param replace {@link BaseObject3D} The child replacing the old child.
+	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 */
+	private void internalReplaceChild(AFrameTask child, BaseObject3D replace, int index) {
+		if (index != AFrameTask.UNUSED_INDEX) {
+			mChildren.set(index, replace);
+		} else {
+			mChildren.set(mChildren.indexOf(child), replace);
+		}
+		//TODO: Handle child replacement in scene graph
+	}
+	
+	/**
+	 * Internal method for adding {@link BaseObject3D} children.
+	 * Should only be called through {@link #handleAddTask(AFrameTask)}
+	 * 
+	 * This takes an index for the addition, but it is pretty
+	 * meaningless.
+	 * 
+	 * @param child {@link BaseObject3D} to add.
+	 * @param int index to add the child at. 
+	 */
+	private void internalAddChild(BaseObject3D child, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mChildren.add(child);
+		} else {
+			mChildren.add(index, child);
+		}
+		if (mSceneGraph != null) {
+			mSceneGraph.addObject(child);
+		}
+	}
+	
+	/**
+	 * Internal method for removing {@link BaseObject3D} children.
+	 * Should only be called through {@link #handleRemoveTask(AFrameTask)}
+	 * 
+	 * This takes an index for the removal. 
+	 * 
+	 * @param child {@link BaseObject3D} to remove. If index is used, this is ignored.
+	 * @param index integer index to remove the child at. 
+	 */
+	private void internalRemoveChild(BaseObject3D child, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mChildren.remove(child);
+		} else {
+			mChildren.remove(index);
+		}
+		if (mSceneGraph != null) {
+			mSceneGraph.removeObject(child);
+		}
+	}
+	
+	/**
+	 * Internal method for removing all {@link BaseObject3D} children.
+	 * Should only be called through {@link #handleRemoveAllTask(AFrameTask)}
+	 */
+	private void internalClearChildren() {
+		if (mSceneGraph != null) {
+			mSceneGraph.removeObjects(new ArrayList<IGraphNodeMember>(mChildren));
+		}
+		mChildren.clear();
+	}
+	
+	/**
+	 * Creates a shallow copy of the internal child list. 
+	 * 
+	 * @return ArrayList containing the children.
+	 */
+	public ArrayList<BaseObject3D> getChildrenCopy() {
+		ArrayList<BaseObject3D> list = new ArrayList<BaseObject3D>();
+		list.addAll(mChildren);
+		return list;
+	}
+
+	/**
+	 * Tests if the specified {@link BaseObject3D} is a child of the renderer.
+	 * 
+	 * @param child {@link BaseObject3D} to check for.
+	 * @return boolean indicating child's presence as a child of the renderer.
+	 */
+	protected boolean hasChild(BaseObject3D child) {
+		//Thread safety deferred to the List.
+		return mChildren.contains(child);
+	}
+	
+	/**
+	 * Retrieve the number of children.
+	 * 
+	 * @return The current number of children.
+	 */
+	public int getNumChildren() {
+		//Thread safety deferred to the List
+		return mChildren.size();
+	}
+
+	/**
+	 * Internal method for replacing a {@link IRendererPlugin}. If index is
+	 * {@link AFrameTask.UNUSED_INDEX} then it will be used, otherwise the replace
+	 * object is used. Should only be called through {@link #handleReplaceTask(AFrameTask)}
+	 * 
+	 * @param plugin {@link IRendererPlugin} The new plugin for the specified index.
+	 * @param replace {@link IRendererPlugin} The plugin replacing the old plugin.
+	 * @param index integer index to effect. Set to {@link AFrameTask.UNUSED_INDEX} if not used.
+	 */
+	private void internalReplacePlugin(AFrameTask plugin, IRendererPlugin replace, int index) {
+		if (index != AFrameTask.UNUSED_INDEX) {
+			mPlugins.set(index, replace);
+		} else {
+			mPlugins.set(mPlugins.indexOf(plugin), replace);
+		}
+	}
+	
+	/**
+	 * Internal method for adding {@link IRendererPlugin} renderer.
+	 * Should only be called through {@link #handleAddTask(AFrameTask)}
+	 * 
+	 * This takes an index for the addition, but it is pretty
+	 * meaningless.
+	 * 
+	 * @param plugin {@link IRendererPlugin} to add.
+	 * @param int index to add the child at. 
+	 */
+	private void internalAddPlugin(IRendererPlugin plugin, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mPlugins.add(plugin);
+		} else {
+			mPlugins.add(index, plugin);
+		}
+	}
+	
+	/**
+	 * Internal method for removing {@link IRendererPlugin} renderer.
+	 * Should only be called through {@link #handleRemoveTask(AFrameTask)}
+	 * 
+	 * This takes an index for the removal. 
+	 * 
+	 * @param plugin {@link IRendererPlugin} to remove. If index is used, this is ignored.
+	 * @param index integer index to remove the child at. 
+	 */
+	private void internalRemovePlugin(IRendererPlugin plugin, int index) {
+		if (index == AFrameTask.UNUSED_INDEX) {
+			mPlugins.remove(plugin);
+		} else {
+			mPlugins.remove(index);
+		}
+	}
+	
+	/**
+	 * Internal method for removing all {@link IRendererPlugin} renderers.
+	 * Should only be called through {@link #handleRemoveAllTask(AFrameTask)}
+	 */
+	private void internalClearPlugins() {
+		mPlugins.clear();
+	}
+	
+	/**
+	 * Creates a shallow copy of the internal plugin list. 
+	 * 
+	 * @return ArrayList containing the plugins.
+	 */
+	public ArrayList<IRendererPlugin> getPluginsCopy() {
+		ArrayList<IRendererPlugin> list = new ArrayList<IRendererPlugin>();
+		list.addAll(mPlugins);
+		return list;
+	}
+
+	/**
+	 * Tests if the specified {@link IRendererPlugin} is a plugin of the renderer.
+	 * 
+	 * @param plugin {@link IRendererPlugin} to check for.
+	 * @return boolean indicating plugin's presence as a plugin of the renderer.
+	 */
+	protected boolean hasPlugin(IRendererPlugin plugin) {
+		//Thread safety deferred to the List.
+		return mPlugins.contains(plugin);
+	}
+	
+	/**
+	 * Retrieve the number of plugins.
+	 * 
+	 * @return The current number of plugins.
+	 */
+	public int getNumPlugins() {
+		//Thread safety deferred to the List
+		return mPlugins.size();
+	}
+	
+	/**
+	 * Reload all the children
+	 */
+	private void reloadChildren() {
+		synchronized (mChildren) {
+			for (int i = 0, j = mChildren.size(); i < j; ++i)
+				mChildren.get(i).reload();
+		}
+	}
+
+	/**
+	 * Reload all the plugins
+	 */
+	private void reloadPlugins() {
+		synchronized (mPlugins) {
+			for (int i = 0, j = mPlugins.size(); i < j; ++i)
+				mPlugins.get(i).reload();
+		}
+	}
+
+	/**
+	 * Clears any references the scene is holding for its contents. This does
+	 * not clear the items themselves as they may be held by some other scene.
+	 */
+	public void destroyScene() {
+		queueClearTask(AFrameTask.TYPE.ANIMATION);
+		queueClearTask(AFrameTask.TYPE.CAMERA);
+		queueClearTask(AFrameTask.TYPE.LIGHT);
+		queueClearTask(AFrameTask.TYPE.OBJECT3D);
+		queueClearTask(AFrameTask.TYPE.PLUGIN);
+	}
+	
+	/**
+	 * Sets the background color of the scene.
+	 * 
+	 * @param red float red component (0-1.0f).
+	 * @param green float green component (0-1.0f).
+	 * @param blue float blue component (0-1.0f).
+	 * @param alpha float alpha component (0-1.0f).
+	 */
+	public void setBackgroundColor(float red, float green, float blue, float alpha) {
+		mRed = red;
+		mGreen = green;
+		mBlue = blue;
+		mAlpha = alpha;
+	}
+	
+	/**
+	 * Sets the background color of the scene. 
+	 * 
+	 * @param color Android color integer.
+	 */
+	public void setBackgroundColor(int color) {
+		setBackgroundColor(Color.red(color) / 255f, Color.green(color) / 255f, Color.blue(color) / 255f, Color.alpha(color) / 255f);
+	}
+	
+	/**
+	 * Retrieves the background color of the scene.
+	 * 
+	 * @return Android color integer.
+	 */
+	public int getBackgroundColor() {
+		return Color.argb((int) (mAlpha*255f), (int) (mRed*255f), (int) (mGreen*255f), (int) (mBlue*255f));
+	}
+	
+	/**
+	 * Updates the projection matrix of the current camera for new view port dimensions.
+	 * 
+	 * @param width int the new viewport width in pixels.
+	 * @param height in the new viewport height in pixes.
+	 */
+	public void updateProjectionMatrix(int width, int height) {
+		mCamera.setProjectionMatrix(width, height);
+	}
+	
+	public void setUsesCoverageAa(boolean value) {
+		mUsesCoverageAa = value;
+	}
+	
+	/**
+	 * Set if the scene graph should be displayed. How it is 
+	 * displayed is left to the implimentation of the graph.
+	 * 
+	 * @param display If true, the scene graph will be displayed.
+	 */
+	public void displaySceneGraph(boolean display) {
+		mDisplaySceneGraph = display;
+	}
+
+	/**
+	 * Retrieve the number of triangles this scene contains.
+	 * 
+	 * @return int the total triangle count for the scene.
+	 */
+	public int getNumTriangles() {
+		int triangleCount = 0;
+		ArrayList<BaseObject3D> children = getChildrenCopy();
+		for (int i = 0, j = children.size(); i < j; i++) {
+			if (children.get(i).getGeometry() != null && children.get(i).getGeometry().getVertices() != null && children.get(i).isVisible())
+				triangleCount += children.get(i).getGeometry().getVertices().limit() / 9;
+		}
+		return triangleCount;
+	}
+
+	@Override
+	public TYPE getFrameTaskType() {
+		return AFrameTask.TYPE.SCENE;
+	}
+}

--- a/src/rajawali/scenegraph/A_nAABBTree.java
+++ b/src/rajawali/scenegraph/A_nAABBTree.java
@@ -1,0 +1,867 @@
+package rajawali.scenegraph;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import android.opengl.Matrix;
+import android.util.Log;
+
+import rajawali.ATransformable3D;
+import rajawali.Camera;
+import rajawali.bounds.BoundingBox;
+import rajawali.bounds.BoundingSphere;
+import rajawali.bounds.IBoundingVolume;
+import rajawali.math.Number3D;
+import rajawali.util.RajLog;
+
+/**
+ * Generic Axis Aligned Bounding Box based tree sorting hierarchy. Subclasses
+ * are left to determine child count and any count specific behavior. This implementation
+ * in general uses the methodology described in the tutorial listed below by Paramike, with
+ * a few modifications to the behavior. 
+ * 
+ * Implementations of this could be Ternary trees (3), Octree (8), Icoseptree (27), etc.
+ * The tree will try to nest objects as deeply as possible while trying to maintain an minimal
+ * tree structure based on the thresholds set. It is up to the user to determine what thresholds
+ * make sense and are optimal for your specific needs as there are tradeoffs associated with
+ * them all. The default implementation attempts to strike a reasonable balance.
+ * 
+ * This tree design also utilizes an option for overlap between child partitions. This is useful
+ * for mimicking some of the behavior of a more complex tree without incurring the complexity. If
+ * you specify an overlap percentage, it is more likely that an object near a boundary of the 
+ * partitions will fit in one or the other and be able to be nested deeper rather than staying in
+ * the parent partition. Note however that in cases where the object is small enough to still be
+ * fully contained by both (or more) children, it is added to the parent. This is where a more
+ * complex tree would excel, but only in the case over very large object counts.
+ * 
+ * By default, this tree will NOT recursively add the children of added objects and NOT
+ * recursively remove the children of removed objects.
+ * 
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ * @see {@link http://www.piko3d.com/tutorials/space-partitioning-tutorial-piko3ds-dynamic-octree}
+ */
+public abstract class A_nAABBTree extends BoundingBox implements IGraphNode {
+
+	protected int CHILD_COUNT = 0; //The number of child nodes used
+
+	protected A_nAABBTree mParent; //Parent partition;
+	protected A_nAABBTree[] mChildren; //Child partitions
+	protected Number3D mChildLengths; //Lengths of each side of the child nodes
+
+	protected boolean mSplit = false; //Have we split to child partitions
+	protected List<IGraphNodeMember> mMembers; //A list of all the member objects
+	protected List<IGraphNodeMember> mOutside; //A list of all the objects outside the root
+
+	protected int mOverlap = 0; //Partition overlap
+	protected int mGrowThreshold = 5; //Threshold at which to grow the graph
+	protected int mShrinkThreshold = 4; //Threshold at which to shrink the graph
+	protected int mSplitThreshold = 5; //Threshold at which to split the node
+	protected int mMergeThreshold = 2; //Threshold at which to merge the node
+
+	protected boolean mRecursiveAdd = false; //Default to NOT recursive add
+	protected boolean mRecursiveRemove = false; //Default to NOT recursive remove.
+
+	protected float[] mMMatrix = new float[16]; //A model matrix to use for drawing the bounds of this node.
+	protected Number3D mPosition; //This node's center point in 3D space.
+
+	/**
+	 * The region (e.g. octant) this node occupies in its parent. If this node
+	 * has no parent this is a meaningless number. A negative
+	 * number is used to represent that there is no region assigned.
+	 */
+	protected int mChildRegion = -1;
+
+	/**
+	 * Default constructor
+	 */
+	protected A_nAABBTree() {
+		super();
+	}
+
+	/**
+	 * Constructor to setup root node with specified merge/split and
+	 * grow/shrink behavior.
+	 * 
+	 * @param maxMembers int containing the divide threshold count. When more 
+	 * members than this are added, a partition will divide into 8 children.
+	 * @param minMembers int containing the merge threshold count. When fewer
+	 * members than this exist, a partition will recursively merge to its ancestors.
+	 * @param overlap int containing the percentage overlap between two adjacent
+	 * partitions. This allows objects to be nested deeper in the tree when they
+	 * would ordinarily span a boundary.
+	 */
+	public A_nAABBTree(int mergeThreshold, int splitThreshold, int shrinkThreshold, int growThreshold, int overlap) {
+		this(null, mergeThreshold, splitThreshold, shrinkThreshold, growThreshold, overlap);
+	}
+
+	/**
+	 * Constructor to setup a child node with specified merge/split and 
+	 * grow/shrink behavior.
+	 * 
+	 * @param parent A_nAABBTree which is the parent of this partition.
+	 * @param maxMembers int containing the divide threshold count. When more 
+	 * members than this are added, a partition will divide into 8 children.
+	 * @param minMembers int containing the merge threshold count. When fewer
+	 * members than this exist, a partition will recursively merge to its ancestors.
+	 * @param overlap int containing the percentage overlap between two adjacent
+	 * partitions. This allows objects to be nested deeper in the tree when they
+	 * would ordinarily span a boundary.
+	 */
+	public A_nAABBTree(A_nAABBTree parent, int mergeThreshold, int splitThreshold, int shrinkThreshold, int growThreshold, int overlap) {
+		mParent = parent;
+		mMergeThreshold = mergeThreshold;
+		mSplitThreshold = splitThreshold;
+		mShrinkThreshold = shrinkThreshold;
+		mGrowThreshold = growThreshold;
+		mOverlap = overlap;
+		init();
+	}
+
+	/**
+	 * Performs the necessary process to destroy this node
+	 */
+	protected abstract void destroy();
+
+	/**
+	 * Calculates the side lengths that child nodes
+	 * of this node should have.
+	 */
+	protected void calculateChildSideLengths() {
+		//Determine the distance on each axis
+		Number3D temp = Number3D.subtract(mTransformedMax, mTransformedMin);
+		temp.multiply(0.5f); //Divide it in half
+		float overlap = 1.0f + mOverlap/100.0f;
+		temp.multiply(overlap);
+		temp.absoluteValue();
+		mChildLengths.setAllFrom(temp);
+	}
+
+	/**
+	 * Sets the bounding volume of this node. This should only be called
+	 * for a root node with no children. This sets the initial root node
+	 * to have a volume ~8x the member, centered on the member.
+	 * 
+	 * @param object IGraphNodeMember the member we will be basing
+	 * our bounds on. 
+	 */
+	protected void setBounds(IGraphNodeMember member) {
+		//RajLog.d("[" + this.getClass().getName() + "] Setting bounds based on member: " + member);
+		if (mMembers.size() != 0 && mParent != null) {return;}
+		IBoundingVolume volume = member.getTransformedBoundingVolume();
+		BoundingBox bcube = null;
+		BoundingSphere bsphere = null;
+		Number3D position = member.getScenePosition();
+		double span_y = 0;
+		double span_x = 0;
+		double span_z = 0;
+		if (volume == null) {
+			span_x = 5.0;
+			span_y = 5.0;
+			span_z = 5.0;
+		} else {
+			if (volume instanceof BoundingBox) {
+				bcube = (BoundingBox) volume;
+				Number3D min = bcube.getTransformedMin();
+				Number3D max = bcube.getTransformedMax();
+				span_x = (max.x - min.x);
+				span_y = (max.y - min.y);
+				span_z = (max.z - min.z);
+			} else if (volume instanceof BoundingSphere) {
+				bsphere = (BoundingSphere) volume;
+				span_x = 2.0*bsphere.getScaledRadius();
+				span_y = span_x;
+				span_z = span_x;
+			}
+		}
+		mMin.x = (float) (position.x - span_x);
+		mMin.y = (float) (position.y - span_y);
+		mMin.z = (float) (position.z - span_z);
+		mMax.x = (float) (position.x + span_x);
+		mMax.y = (float) (position.y + span_y);
+		mMax.z = (float) (position.z + span_z);
+		mTransformedMin.setAllFrom(mMin);
+		mTransformedMax.setAllFrom(mMax);
+		calculatePoints();
+		calculateChildSideLengths();
+	}
+
+	/**
+	 * Sets the bounding volume of this node to that of the specified
+	 * child. This should only be called for a root node during a shrink
+	 * operation. 
+	 * 
+	 * @param child int Which octant to match.
+	 */
+	protected void setBounds(int child) {
+		A_nAABBTree new_bounds = mChildren[child];
+		mMin.setAllFrom(new_bounds.mMin);
+		mMax.setAllFrom(new_bounds.mMax);
+		mTransformedMin.setAllFrom(mMin);
+		mTransformedMax.setAllFrom(mMax);
+		calculatePoints();
+		calculateChildSideLengths();
+	}
+
+	/**
+	 * Sets the region this node occupies in its parent.
+	 * Subclasses should be sure to call the super implementation
+	 * to avoid unexpected behavior.
+	 * 
+	 * @param region Integer region this child occupies.
+	 * @param size Number3D containing the length for each
+	 * side this node should be. 
+	 */
+	protected void setChildRegion(int region, Number3D side_lengths) {
+		mTransformedMin.setAllFrom(mMin);
+		mTransformedMax.setAllFrom(mMax);
+		calculatePoints();
+		calculateChildSideLengths();
+		if (mSplit) {
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				mChildren[i].setChildRegion(i, mChildLengths);
+			}
+		}
+	}
+
+	/**
+	 * Retrieve the octant this node resides in.
+	 * 
+	 * @return integer The octant.
+	 */
+	protected int getChildRegion() {
+		return mChildRegion;
+	}
+
+	/**
+	 * Sets the threshold for growing the tree.
+	 * 
+	 * @param threshold int containing the new threshold.
+	 */
+	public void setGrowThreshold(int threshold) {
+		mGrowThreshold = threshold;
+	}
+
+	/**
+	 * Sets the threshold for shrinking the tree.
+	 * 
+	 * @param threshold int containing the new threshold.
+	 */
+	public void setShrinkThreshold(int threshold) {
+		mShrinkThreshold = threshold;
+	}
+
+	/**
+	 * Sets the threshold for merging this node.
+	 * 
+	 * @param threshold int containing the new threshold.
+	 */
+	public void setMergeThreshold(int threshold) {
+		mMergeThreshold = threshold;
+	}
+
+	/**
+	 * Sets the threshold for splitting this node.
+	 * 
+	 * @param threshold int containing the new threshold.
+	 */
+	public void setSplitThreshold(int threshold) {
+		mSplitThreshold = threshold;
+	}
+
+	/**
+	 * Adds the specified object to this node's internal member
+	 * list and sets the node attribute on the member to this
+	 * node.
+	 * 
+	 * @param object IGraphNodeMember to be added.
+	 */
+	protected void addToMembers(IGraphNodeMember object) {
+		RajLog.d("[" + this.getClass().getName() + "] Adding object: " + object + " to members list in: " + this); 
+		object.getTransformedBoundingVolume().setBoundingColor(mBoundingColor.get());
+		object.setGraphNode(this, true);
+		mMembers.add(object);
+	}
+
+	/**
+	 * Removes the specified object from this node's internal member
+	 * list and sets the node attribute on the member to null.
+	 * 
+	 * @param object IGraphNodeMember to be removed.
+	 */
+	protected void removeFromMembers(IGraphNodeMember object) {
+		RajLog.d("[" + this.getClass().getName() + "] Removing object: " + object + " from members list in: " + this);
+		object.getTransformedBoundingVolume().setBoundingColor(IBoundingVolume.DEFAULT_COLOR);
+		object.setGraphNode(null, false);
+		mMembers.remove(object);
+	}
+
+	/**
+	 * Adds the specified object to the scenegraph's outside member
+	 * list and sets the node attribute on the member to the root node.
+	 * 
+	 * @param object IGraphNodeMember to be added.
+	 */
+	protected void addToOutside(IGraphNodeMember object) {
+		if (mOutside.contains(object)) return;
+		mOutside.add(object);
+		object.setGraphNode(this, false);
+		object.getTransformedBoundingVolume().setBoundingColor(IBoundingVolume.DEFAULT_COLOR);
+	}
+
+	/**
+	 * Returns a list of all members of this node and any decendent nodes.
+	 * 
+	 * @param shouldClear boolean indicating if the search should clear the lists.
+	 * @return ArrayList of IGraphNodeMembers.
+	 */
+	protected ArrayList<IGraphNodeMember> getAllMembersRecursively(boolean shouldClear) {
+		ArrayList<IGraphNodeMember> members = new ArrayList<IGraphNodeMember>();
+		members.addAll(mMembers);
+		if (mParent == null) {
+			members.addAll(mOutside);
+		}
+		if (shouldClear) clear();
+		if (mSplit) {
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				members.addAll(mChildren[i].mMembers);
+				if (shouldClear) mChildren[i].clear();
+			}
+		}
+		return members;
+	}
+
+	/**
+	 * Internal method for adding an object to the graph. This method will determine if
+	 * it gets added to this node or moved to a child node.
+	 * 
+	 * @param object IGraphNodeMember to be added.
+	 */ 
+	protected void internalAddObject(IGraphNodeMember object) {
+		//TODO: Implement a batch process for this to save excessive splitting/merging
+		if (mSplit) {
+			//Check if the object fits in our children
+			int fits_in_child = -1;
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				if (mChildren[i].contains(object.getTransformedBoundingVolume())) {
+					//If the member fits in this child, mark that child
+					if (fits_in_child < 0) {
+						fits_in_child = i;
+					} else {
+						//It fits in multiple children, leave it in parent
+						fits_in_child = -1;
+						break;
+					}
+				}
+			}
+			if (fits_in_child >= 0) { //If a single child was marked, add the member to it
+				mChildren[fits_in_child].addObject(object);
+			} else {
+				//It didn't fit in any of the children, so store it here
+				addToMembers(object);
+			}
+		} else {
+			//We just add it to this node, then check if we should split
+			addToMembers(object);
+			if (mMembers.size() >= mSplitThreshold) {
+				split();
+			}
+		}
+	}
+
+	/**
+	 * Adds an object back into the graph when shrinking.
+	 * 
+	 * @param object The object to be handled.
+	 */
+	protected void shrinkAddObject(IGraphNodeMember object) {
+		if (contains(object.getTransformedBoundingVolume())) {
+			internalAddObject(object);
+		} else {
+			addToOutside(object);
+		}
+	}
+
+	/**
+	 * Splits this node into child nodes. Subclasses
+	 * should be sure to call the super implementation
+	 * to avoid unexpected behavior.
+	 */
+	protected void split() {
+		//Keep a list of members we have removed
+		ArrayList<IGraphNodeMember> removed = new ArrayList<IGraphNodeMember>();
+		for (int i = 0; i < mMembers.size(); ++i) {
+			int fits_in_child = -1;
+			IGraphNodeMember member = mMembers.get(i);
+			for (int j = 0; j < CHILD_COUNT; ++j) {
+				if (mChildren[j].contains(member.getTransformedBoundingVolume())) {
+					//If the member fits in this child, mark that child
+					if (fits_in_child < 0) {
+						fits_in_child = j;
+					} else {
+						//It fits in multiple children, leave it in parent
+						fits_in_child = -1;
+						break;
+					}
+				}
+			}
+			if (fits_in_child >= 0) { //If a single child was marked, add the member to it
+				mChildren[fits_in_child].addObject(member);
+				removed.add(member); //Mark the member for removal from parent
+			}
+		}
+		//Now remove all of the members marked for removal
+		mMembers.removeAll(removed);
+		mSplit = true; //Flag that we have split
+	}
+
+	/**
+	 * Merges this child nodes into their parent node. 
+	 */
+	protected void merge() {
+		RajLog.d("[" + this.getClass().getName() + "] Merge nodes called on node: " + this);
+		if (mParent != null && mParent.canMerge()) {
+			RajLog.d("[" + this.getClass().getName() + "] Parent can merge...passing call up.");
+			mParent.merge();
+		} else {
+			if (mSplit) {
+				for (int i = 0; i < CHILD_COUNT; ++i) {
+					//Add all the members of all the children
+					ArrayList<IGraphNodeMember> members = mChildren[i].getAllMembersRecursively(false);
+					int members_count = members.size();
+					for (int j = 0; j < members_count; ++j) {
+						addToMembers(members.get(j));
+					}
+					mChildren[i].destroy();
+					mChildren[i] = null;
+				}
+				mSplit = false;
+			}
+		}
+	}
+
+	/**
+	 * Grows the tree.
+	 */
+	protected void grow() {
+		RajLog.d("[" + this.getClass().getName() + "] Growing tree: " + this);
+		Number3D min = new Number3D(Float.MAX_VALUE, Float.MAX_VALUE, Float.MAX_VALUE);
+		Number3D max = new Number3D(-Float.MAX_VALUE, -Float.MAX_VALUE, -Float.MAX_VALUE);
+		//Get a full list of all the members, including members in the children
+		ArrayList<IGraphNodeMember> members = getAllMembersRecursively(true);
+		int members_count = members.size();
+		for (int i = 0; i < members_count; ++i) {
+			IBoundingVolume volume = members.get(i).getTransformedBoundingVolume();
+			Number3D test_against_min = null;
+			Number3D test_against_max = null;
+			if (volume == null) {
+				ATransformable3D object = (ATransformable3D) members.get(i);
+				test_against_min = object.getPosition();
+				test_against_max = test_against_min;
+			} else {
+				if (volume instanceof BoundingBox) {
+					BoundingBox bb = (BoundingBox) volume;
+					test_against_min = bb.getTransformedMin();
+					test_against_max = bb.getTransformedMax();
+				} else if (volume instanceof BoundingSphere) {
+					BoundingSphere bs = (BoundingSphere) volume;
+					Number3D bs_position = bs.getPosition();
+					float radius = bs.getScaledRadius();
+					Number3D rad = new Number3D();
+					rad.setAll(radius, radius, radius);
+					test_against_min = Number3D.subtract(bs_position, rad);
+					test_against_max = Number3D.add(bs_position, rad);
+				} else {
+					RajLog.e("[" + this.getClass().getName() + "] Received a bounding box of unknown type.");
+					throw new IllegalArgumentException("Received a bounding box of unknown type."); 
+				}
+			}
+			if (test_against_min != null && test_against_max != null) {
+				if(test_against_min.x < min.x) min.x = test_against_min.x;
+				if(test_against_min.y < min.y) min.y = test_against_min.y;
+				if(test_against_min.z < min.z) min.z = test_against_min.z;
+				if(test_against_max.x > max.x) max.x = test_against_max.x;
+				if(test_against_max.y > max.y) max.y = test_against_max.y;
+				if(test_against_max.z > max.z) max.z = test_against_max.z;
+			}
+		}
+		mMin.setAllFrom(min);
+		mMax.setAllFrom(max);
+		mTransformedMin.setAllFrom(min);
+		mTransformedMax.setAllFrom(max);
+		calculatePoints();
+		calculateChildSideLengths();
+		if (mSplit) {
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				((Octree) mChildren[i]).setChildRegion(i, mChildLengths);
+			}
+		}
+		for (int i = 0; i < members_count; ++i) {
+			internalAddObject(members.get(i));
+		}
+	}
+
+	/**
+	 * Initializes the storage elements of the tree.
+	 */
+	protected abstract void init();
+
+	/**
+	 * Shrinks the tree. Should only be called by root node.
+	 */
+	protected void shrink() {
+		if (mParent != null) {
+			throw new IllegalStateException("Shrink can only be called by the root node.");
+		}
+		RajLog.d("[" + this.getClass().getName() + "] Checking if tree should be shrunk.");
+		int maxCount = 0;
+		int index_max = -1;
+		for (int i = 0; i < CHILD_COUNT; ++i) { //For each child, get the object count and find the max
+			if (mChildren[i].getObjectCount() > maxCount) {
+				maxCount = mChildren[i].getObjectCount();
+				index_max = i;
+			}
+		}
+		if (index_max >= 0) {
+			for (int i = 0; i < CHILD_COUNT; ++i) { //Validate shrink
+				if (i == index_max) {
+					continue;
+				} else if (mChildren[i].getObjectCount() == maxCount) { 
+					//If there are two+ children with the max count, shrinking doesnt make sense
+					return;
+				}
+			}
+			if ((getObjectCount() - maxCount) <= mShrinkThreshold) {
+				RajLog.d("[" + this.getClass().getName() + "] Shrinking tree.");
+				ArrayList<IGraphNodeMember> members = getAllMembersRecursively(true);
+				int members_count = members.size();
+				setBounds(index_max);
+				if (mSplit) {
+					for (int i = 0; i < CHILD_COUNT; ++i) { 
+						//TODO: This is not always necessary depending on the object count, a GC improvement can be made here
+						mChildren[i].destroy();
+						mChildren[i] = null;
+					}
+					mSplit = false;
+				}
+				for (int i = 0; i < members_count; ++i) {
+					shrinkAddObject(members.get(i));
+				}
+			}
+		}
+	}
+
+	/**
+	 * Determines if this node can be merged.
+	 * 
+	 * @return boolean indicating merge status.
+	 */
+	public boolean canMerge() {
+		//Determine recursive member count
+		int count = mMembers.size();
+		if (mSplit) {
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				count += mChildren[i].mMembers.size();
+			}
+		}
+		return (count <= mMergeThreshold);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#clear()
+	 */
+	public void clear() {
+		mMembers.clear();
+		if (mParent == null) {
+			mOutside.clear();
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#addObject(rajawali.scenegraph.IGraphNodeMember)
+	 */
+	public synchronized void addObject(IGraphNodeMember object) {
+		RajLog.d("[" + this.getClass().getName() + "] Adding object: " + object + " to octree."); 
+		//TODO: Handle recursive add posibility
+
+		if (mParent == null) {
+			//We are the root node
+			mBoundingColor.set(0xFFFF0000);
+			if (getObjectCount() == 0) {
+				//Set bounds based the incoming objects bounding box
+				setBounds(object); 
+				addToMembers(object);
+			} else {
+				//Check if object is in bounds
+				if (contains(object.getTransformedBoundingVolume())) {
+					//The object is fully in bounds
+					internalAddObject(object);
+				} else {
+					//The object is not in bounds or only partially in bounds
+					//Add it to the outside container
+					addToOutside(object);
+					if (mOutside.size() >= mGrowThreshold) {
+						grow();
+					}
+				}
+			}
+		} else {
+			//We are a branch or leaf node
+			internalAddObject(object);
+		}
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#addObjects(java.util.Collection)
+	 */
+	public void addObjects(Collection<IGraphNodeMember> objects) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#removeObject(rajawali.ATransformable3D)
+	 */
+	public synchronized void removeObject(IGraphNodeMember object) {
+		RajLog.d("[" + this.getClass().getName() + "] Removing object: " + object + " from octree.");
+		//TODO: Handle recursive add posibility
+		//Retrieve the container object
+		IGraphNode container = object.getGraphNode();
+		if (container == null) {
+			mOutside.remove(object);
+		} else {
+			if (container == this) {
+				//If this is the container, process the removal
+				//Remove the object from the members
+				removeFromMembers(object);
+				if (canMerge() && mParent != null) {
+					//If we can merge, do it (if we are the root node, we can't)
+					merge();
+				}
+			} else {
+				//Defer the removal to the container
+				container.removeObject(object);
+			}
+		}
+		if (mParent == null && mSplit) shrink(); //Try to shrink the tree
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#removeObjects(java.util.Collection)
+	 */
+	public void removeObjects(Collection<IGraphNodeMember> objects) {
+		// TODO Auto-generated method stub
+		
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#updateObject(rajawali.ATransformable3D)
+	 */
+	public synchronized void updateObject(IGraphNodeMember object) {
+		/*RajLog.d("[" + this.getClass().getName() + "] Updating object: " + object + 
+				"[" + object.getClass().getName() + "] in octree.");*/
+		if (mParent == null && getObjectCount() == 1) { //If there is only one object, we should just follow it
+			setBounds(object);			
+			return;
+		}
+		IGraphNode container = object.getGraphNode(); //Get the container node
+		handleRecursiveUpdate((A_nAABBTree) container, object);
+		Log.e("Rajawali", "Node: " + this + " Object Container: " + container);
+	}
+
+	/**
+	 * Handles the potentially recursive process of the update. Will determine which node
+	 * the object is now within.
+	 * 
+	 * @param container A_nAABBTree instance which is the prior container.
+	 * @param object IGraphNodeMember which is being updated.
+	 */
+	protected void handleRecursiveUpdate(final A_nAABBTree container, IGraphNodeMember object) {
+		//Log.i("Rajawali", "Handling recursive update potential.");
+		A_nAABBTree local_container = container;
+		boolean updated = false;
+		while (!updated) {
+			if (local_container.contains(object.getTransformedBoundingVolume())) {
+				Log.v("Rajawali", "INSIDE");
+				int fits_in_child = -1;
+				if (mSplit) {
+					for (int j = 0; j < CHILD_COUNT; ++j) {
+						if (mChildren[j].contains(object.getTransformedBoundingVolume())) {
+							//If the member fits in this child, mark that child
+							if (fits_in_child < 0) {
+								fits_in_child = j;
+							} else {
+								//It fits in multiple children, leave it in parent
+								fits_in_child = -1;
+								break;
+							}
+						}
+					}
+					if (fits_in_child >= 0) { //If a single child was marked
+						Log.i("Rajawali", "Fits in a single child.");
+						local_container.removeFromMembers(object);
+						mChildren[fits_in_child].internalAddObject(object);
+						updated = true;
+					} else { //TODO: WORKS
+						Log.i("Rajwali", "Fits in multiple children, leaving in place.");
+						updated = true;
+					}
+				} else {
+					Log.i("Rajawali", "No children so we are leaving in same node.");
+					if (!object.isInGraph()) {
+						Log.i("Rajawali", "Removing from outside graph and moving to inside root.");
+						local_container.mOutside.remove(object);
+						local_container.internalAddObject(object);
+					}
+					updated = true;
+				}
+			} else {
+				//Log.v("Rajawali", "OUTSIDE");
+				if (local_container.mParent == null) { //TODO: WORKS
+					//Log.v("Rajawali", "OUTSIDE");
+					//Log.i("Rajawali", "Container is root node. Adding to outside.");
+					if (object.isInGraph()) {
+						local_container.removeFromMembers(object);
+						local_container.addToOutside(object);
+					}
+					//Log.e("Rajawali", "Node after addToOutside: " + object.getGraphNode());
+					updated = true;
+				} else {
+					Log.i("Rajawali", "Container is not root (" + local_container + "). Moving search up a level.");
+					local_container = local_container.mParent;
+				}
+			}
+		}
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#rebuild()
+	 */
+	public void rebuild() {
+		// TODO Auto-generated method stub
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#addChildrenRecursively(boolean)
+	 */
+	public void addChildrenRecursively(boolean recursive) {
+		mRecursiveAdd = recursive;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#removeChildrenRecursively(boolean)
+	 */
+	public void removeChildrenRecursively(boolean recursive) {
+		mRecursiveRemove = recursive;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#cullFromBoundingVolume(rajawali.bounds.IBoundingVolume)
+	 */
+	public void cullFromBoundingVolume(IBoundingVolume volume) {
+		// TODO Auto-generated method stub
+
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#displayGraph(boolean)
+	 */
+	public void displayGraph(Camera camera, float[] projMatrix, float[] vMatrix) {
+		Matrix.setIdentityM(mMMatrix, 0);
+		drawBoundingVolume(camera, projMatrix, vMatrix, mMMatrix);
+		if (mSplit) {
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				mChildren[i].displayGraph(camera, projMatrix, vMatrix);
+			}
+		}
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#getSceneMinBound()
+	 */
+	public Number3D getSceneMinBound() {
+		return getTransformedMin();
+	}
+	
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#getSceneMaxBound()
+	 */
+	public Number3D getSceneMaxBound() {
+		return getTransformedMax();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#getObjectCount()
+	 */
+	public int getObjectCount() {
+		int count = mMembers.size();
+		if (mParent == null) {
+			count += mOutside.size();
+		}
+		if (mSplit) {
+			for (int i = 0; i < CHILD_COUNT; ++i) {
+				count += mChildren[i].getObjectCount();
+			}
+		}
+		return count;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#contains(rajawali.bounds.IBoundingVolume)
+	 */
+	public boolean contains(IBoundingVolume boundingVolume) {
+		if(!(boundingVolume instanceof BoundingBox)) return false;
+		BoundingBox boundingBox = (BoundingBox)boundingVolume;
+		Number3D otherMin = boundingBox.getTransformedMin();
+		Number3D otherMax = boundingBox.getTransformedMax();
+		Number3D min = mTransformedMin;
+		Number3D max = mTransformedMax;		
+
+		return (max.x >= otherMax.x) && (min.x <= otherMin.x) &&
+				(max.y >= otherMax.y) && (min.y <= otherMin.y) &&
+				(max.z >= otherMax.z) && (min.z <= otherMin.z);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.IGraphNode#isContainedBy(rajawali.bounds.IBoundingVolume)
+	 */
+	public boolean isContainedBy(IBoundingVolume boundingVolume) {
+		if(!(boundingVolume instanceof BoundingBox)) return false;
+		BoundingBox boundingBox = (BoundingBox)boundingVolume;
+		Number3D otherMin = boundingBox.getTransformedMin();
+		Number3D otherMax = boundingBox.getTransformedMax();
+		Number3D min = mTransformedMin;
+		Number3D max = mTransformedMax;		
+
+		return (max.x <= otherMax.x) && (min.x >= otherMin.x) &&
+				(max.y <= otherMax.y) && (min.y >= otherMin.y) &&
+				(max.z <= otherMax.z) && (min.z >= otherMin.z);
+	}
+
+	@Override
+	public String toString() {
+		String str = "A_nAABBTree: " + mChildRegion + " member/outside count: " + mMembers.size() + "/";
+		if (mParent == null) {
+			str = str + mOutside.size();
+		} else {
+			str = str + "NULL";
+		}
+		return str;
+	}
+}

--- a/src/rajawali/scenegraph/IGraphNode.java
+++ b/src/rajawali/scenegraph/IGraphNode.java
@@ -1,0 +1,158 @@
+package rajawali.scenegraph;
+
+import java.util.Collection;
+
+import rajawali.Camera;
+import rajawali.bounds.IBoundingVolume;
+import rajawali.math.Number3D;
+import rajawali.scene.RajawaliScene;
+
+
+/**
+ * Generic interface allowing for the incorporation of scene graphs
+ * to the rendering pipeline of Rajawali. To be a member of scene graphs
+ * which implement this interface, an object must inherit from 
+ * ATransformable3D. 
+ * 
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public interface IGraphNode {
+	
+	/**
+	 * This enum defines the different scene graphs which {@link RajawaliScene}
+	 * can use. If a new type is created it should be added to this list. 
+	 */
+	public enum GRAPH_TYPE {
+		NONE, OCTREE
+	}
+	
+	/**
+	 * Adds an object to the scene graph. Implementations do not
+	 * need to support online adjustment of the scene graph, and
+	 * should clearly document what their add behavior is.
+	 * 
+	 * @param object BaseObject3D to be added to the graph.
+	 */
+	public void addObject(IGraphNodeMember object);
+	
+	/**
+	 * Adds a collection of objects to the scene graph. Implementations
+	 * do not need to support online adustment of the scene graph, and
+	 * should clearly document what their add behavior is.
+	 * 
+	 * @param objects Collection of {@link IGraphNodeMember} objects to add.
+	 */
+	public void addObjects(Collection<IGraphNodeMember> objects);
+	
+	/**
+	 * Removes an object from the scene graph. Implementations do not
+	 * need to support online adjustment of the scene graph, and should
+	 * clearly document what their removal behavior is. 
+	 * 
+	 * @param object BaseObject3D to be removed from the graph.
+	 */
+	public void removeObject(IGraphNodeMember object);
+	
+	/**
+	 * Removes a collection of objects from the scene graph. Implementations do not
+	 * need to support online adjustment of the scene graph, and should
+	 * clearly document what thier removal behavior is.
+	 * 
+	 * @param objects Collection of {@link IGraphNodeMember} objects to remove.
+	 */
+	public void removeObjects(Collection<IGraphNodeMember> objects);
+	
+	/**
+	 * This should be called whenever an object has moved in the scene.
+	 * Implementations should determine its new position in the graph.
+	 * 
+	 * @param object BaseObject3D to re-examine.
+	 */
+	public void updateObject(IGraphNodeMember object);
+	
+	/**
+	 * Set the child addition behavior. Implementations are expected
+	 * to document their default behavior.
+	 * 
+	 * @param recursive boolean Should the children be added recursively.
+	 */
+	public void addChildrenRecursively(boolean recursive);
+	
+	/**
+	 * Set the child removal behavior. Implementations are expected to
+	 * document their default behavior.
+	 * 
+	 * @param recursive boolean Should the children be removed recursively.
+	 */
+	public void removeChildrenRecursively(boolean recursive);
+	
+	/**
+	 * Can be called to force a reconstruction of the scene graph
+	 * with all added children. This is useful if the scene graph
+	 * does not support online modification.
+	 */
+	public void rebuild();
+	
+	/**
+	 * Can be called to remove all objects from the scene graph.
+	 */
+	public void clear();
+	
+	/**
+	 * Called to cause the scene graph to determine which objects are
+	 * contained (even partially) by the provided volume. How this is 
+	 * done is left to the implementation.
+	 * 
+	 * @param volume IBoundingVolume to test visibility against.
+	 */
+	public void cullFromBoundingVolume(IBoundingVolume volume);
+	
+	/**
+	 * Call this in the renderer to cause the scene graph to be
+	 * displayed. It is up to the implementation to determine 
+	 * the best way to accomplish this (draw volumes, write text,
+	 * log statements, etc.)
+	 * 
+	 * @param display boolean indicating if the graph is to be displayed.
+	 */
+	public void displayGraph(Camera camera, float[] projMatrix, float[] vMatrix);
+	
+	/**
+	 * Retrieve the minimum bounds of this scene.
+	 * 
+	 * @return {@link Number3D} The components represent the minimum value in each axis.
+	 */
+	public Number3D getSceneMinBound();
+	
+	/**
+	 * Retrieve the maximum bounds of this scene.
+	 * 
+	 * @return {@link Number3D} The components represent the maximum value in each axis.
+	 */
+	public Number3D getSceneMaxBound();
+	
+	/**
+	 * Retrieve the number of objects this node is aware of. This count should
+	 * be recursive, meaning each node should ask its children for a count and
+	 * return the sum of that count.
+	 * 
+	 * @return int containing the object count.
+	 */
+	public int getObjectCount();
+	
+	/**
+	 * Does this volume fully contain the input volume.
+	 * 
+	 * @param boundingVolume Volume to check containment of.
+	 * @return boolean result of containment test.
+	 */
+	public boolean contains(IBoundingVolume boundingVolume);
+	
+	/**
+	 * Is this volume fully contained by the input volume.
+	 * 
+	 * @param boundingVolume Volume to check containment by.
+	 * @return boolean result of containment test.
+	 */
+	public boolean isContainedBy(IBoundingVolume boundingVolume);
+}

--- a/src/rajawali/scenegraph/IGraphNodeMember.java
+++ b/src/rajawali/scenegraph/IGraphNodeMember.java
@@ -1,0 +1,49 @@
+package rajawali.scenegraph;
+
+import rajawali.bounds.IBoundingVolume;
+import rajawali.math.Number3D;
+
+/**
+ * Generic interface which any member of IGraphNode must
+ * implement in order to be a part of the graph.
+ * 
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public interface IGraphNodeMember {
+
+	/**
+	 * Sets the node that this member is contained in.
+	 * 
+	 * @param node IGraphNode this member was placed inside.
+	 * @param inside Boolean indicating if this object is inside the graph.
+	 */
+	public void setGraphNode(IGraphNode node, boolean inside);
+	
+	/**
+	 * Gets the node that this member is contained in.
+	 * 
+	 * @return IGraphNode this member was placed inside.
+	 */
+	public IGraphNode getGraphNode();
+	
+	/**
+	 * Gets the objects state in the graph.
+	 * 
+	 * @return True if the object is inside the graph.
+	 */
+	public boolean isInGraph();
+	
+	/**
+	 * Retrieve the bounding volume of this member.
+	 * 
+	 * @return IBoundingVolume which encloses this members "geometry."
+	 */
+	public IBoundingVolume getTransformedBoundingVolume();
+	
+	/**
+	 * Retrieve the position in the scene of this member.
+	 * 
+	 * @return Number3D containing the position.
+	 */
+	public Number3D getScenePosition();
+}

--- a/src/rajawali/scenegraph/Octree.java
+++ b/src/rajawali/scenegraph/Octree.java
@@ -1,0 +1,216 @@
+package rajawali.scenegraph;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+import rajawali.math.Number3D;
+import rajawali.util.RajLog;
+
+
+/**
+ * Octree implementation specific to the Rajawali library.
+ * 
+ * Child partitions will inherit the behavior (recursive add, division threshold, etc.)
+ * of the root node in the graph.
+ * 
+ * This system divides space into 8 equal portions called octants.
+ * 
+ * The octant order follows the conventional algebraic numbering
+ * for 3D Euclidean space. Note that they follow the axis ordering
+ * and OpenGL uses a rotated coordinate system when compared to 
+ * Euclidean mathematics. Thus, assuming no camera rotation or similar
+ * effects:
+ * @see <a href="http://en.wikipedia.org/wiki/Octant_(solid_geometry)">
+	 http://en.wikipedia.org/wiki/Octant_(solid_geometry)</a>
+ * <pre> 
+ *     Octant     | Screen Region
+ * ---------------|---------------
+ *       0        | +X/+Y/+Z
+ *       1        | -X/+Y/+Z 
+ *       2        | -X/-Y/+Z
+ *       3        | +X/-Y/+Z
+ *       4        | +X/+Y/-Z
+ *       5        | -X/+Y/-Z
+ *       6        | -X/-Y/-Z
+ *       7        | +X/-Y/-Z
+ * </pre>
+ * 
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public class Octree extends A_nAABBTree {
+
+	protected static final int[] COLORS = new int[]{
+		0xFF8A2BE2, 0xFF0000FF, 0xFFD2691E, 0xFF008000,
+		0xFFD2B000, 0xFF00FF00, 0xFFFF00FF, 0xFF40E0D0
+	};
+
+	/**
+	 * Default constructor. Initializes the root node with default merge/division
+	 * behavior.
+	 */
+	public Octree() {
+		super();
+		init();
+	}
+
+	/**
+	 * Constructor to setup root node with specified merge/split and
+	 * grow/shrink behavior.
+	 * 
+	 * @param maxMembers int containing the divide threshold count. When more 
+	 * members than this are added, a partition will divide into 8 children.
+	 * @param minMembers int containing the merge threshold count. When fewer
+	 * members than this exist, a partition will recursively merge to its ancestors.
+	 * @param overlap int containing the percentage overlap between two adjacent
+	 * partitions. This allows objects to be nested deeper in the tree when they
+	 * would ordinarily span a boundry.
+	 */
+	public Octree(int mergeThreshold, int splitThreshold, int shrinkThreshold, int growThreshold, int overlap) {
+		super(mergeThreshold, splitThreshold, shrinkThreshold, growThreshold, overlap);
+	}
+
+	/**
+	 * Constructor to setup a child node with specified merge/split and 
+	 * grow/shrink behavior.
+	 * 
+	 * @param parent Octree which is the parent of this partition.
+	 * @param maxMembers int containing the divide threshold count. When more 
+	 * members than this are added, a partition will divide into 8 children.
+	 * @param minMembers int containing the merge threshold count. When fewer
+	 * members than this exist, a partition will recursively merge to its ancestors.
+	 * @param overlap int containing the percentage overlap between two adjacent
+	 * partitions. This allows objects to be nested deeper in the tree when they
+	 * would ordinarily span a boundry.
+	 */
+	public Octree(Octree parent, int mergeThreshold, int splitThreshold, int shrinkThreshold, int growThreshold, int overlap) {
+		super(parent, mergeThreshold, splitThreshold, shrinkThreshold, growThreshold, overlap);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.AD_AABBTree#init()
+	 */
+	@Override
+	protected void init() {
+		//Pre-allocate storage here to favor modification speed
+		CHILD_COUNT = 8;
+		mChildren = new Octree[CHILD_COUNT];
+		mMembers = Collections.synchronizedList(new CopyOnWriteArrayList<IGraphNodeMember>());
+		if (mParent == null) //mOutside should not be used for children, thus we want to force the Null pointer.
+			mOutside = Collections.synchronizedList(new CopyOnWriteArrayList<IGraphNodeMember>());
+		mChildLengths = new Number3D();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.A_nAABBTree#setChildRegion(int, rajawali.math.Number3D)
+	 */
+	@Override
+	protected void setChildRegion(int octant, Number3D side_lengths) {
+		mChildRegion = octant;
+		Number3D min = mParent.getMin();
+		Number3D max = mParent.getMax();
+		switch (mChildRegion) {
+		case 0: //+X/+Y/+Z
+			mMax.setAllFrom(mParent.getMax());
+			mMin.setAllFrom(Number3D.subtract(mMax, side_lengths));
+			break;
+		case 1: //-X/+Y/+Z 
+			mMax.x = min.x + side_lengths.x;
+			mMax.y = max.y;
+			mMax.z = max.z;
+			mMin.x = min.x;
+			mMin.y = max.y - side_lengths.y;
+			mMin.z = max.z - side_lengths.z;
+			break;
+		case 2: //-X/-Y/+Z
+			mMax.x = min.x + side_lengths.x;
+			mMax.y = min.y + side_lengths.y;
+			mMax.z = max.z;
+			mMin.x = min.x;
+			mMin.y = min.y;
+			mMin.z = max.z - side_lengths.z;
+			break;
+		case 3: //+X/-Y/+Z
+			mMax.x = max.x;
+			mMax.y = min.y + side_lengths.y;
+			mMax.z = max.z;
+			mMin.x = max.x - side_lengths.x;
+			mMin.y = min.y;
+			mMin.z = max.z - side_lengths.z;
+			break;
+		case 4: //+X/+Y/-Z
+			mMax.x = max.x;
+			mMax.y = max.y;
+			mMax.z = min.z + side_lengths.z;
+			mMin.x = max.x - side_lengths.x;
+			mMin.y = max.y - side_lengths.y;
+			mMin.z = min.z;
+			break;
+		case 5: //-X/+Y/-Z
+			mMax.x = min.x + side_lengths.x;
+			mMax.y = max.y;
+			mMax.z = min.z + side_lengths.z;
+			mMin.x = min.x;
+			mMin.y = max.y - side_lengths.y;
+			mMin.z = min.z;
+			break;
+		case 6: //-X/-Y/-Z
+			mMin.setAllFrom(min);
+			mMax.setAllFrom(Number3D.add(mMin, side_lengths));
+			break;
+		case 7: //+X/-Y/-Z
+			mMax.x = max.x;
+			mMax.y = min.y + side_lengths.y;
+			mMax.z = min.z + side_lengths.z;
+			mMin.x = max.x - side_lengths.x;
+			mMin.y = min.y;
+			mMin.z = min.z;
+			break;
+		default:
+			return;
+		}
+		super.setChildRegion(octant, side_lengths);
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.A_nAABBTree#destroy()
+	 */
+	@Override
+	protected void destroy() {
+		RajLog.d("[" + this.getClass().getName() + "] Destroying octree node: " + this);
+		//TODO: Implement
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see rajawali.scenegraph.A_nAABBTree#split()
+	 */
+	@Override
+	protected void split() {
+		RajLog.d("[" + this.getClass().getName() + "] Spliting node: " + this);
+		//Populate child array
+		for (int i = 0; i < CHILD_COUNT; ++i) {
+			if (mChildren[i] == null) {
+				mChildren[i] = new Octree(this, mMergeThreshold,
+						mSplitThreshold, mShrinkThreshold, mGrowThreshold, mOverlap);
+			}
+			mChildren[i].setBoundingColor(COLORS[i]);
+			mChildren[i].setChildRegion(i, mChildLengths);
+		}
+		super.split();
+	}
+
+	@Override
+	public String toString() {
+		String str = "Octant: " + mChildRegion + " member/outside count: " + mMembers.size() + "/";
+		if (mParent == null) {
+			str = str + mOutside.size();
+		} else {
+			str = str + "NULL";
+		}
+		return str;
+	}
+}

--- a/src/rajawali/util/ObjectColorPicker.java
+++ b/src/rajawali/util/ObjectColorPicker.java
@@ -95,7 +95,7 @@ public class ObjectColorPicker implements IObjectPicker {
 	}
 
 	public void getObjectAt(float x, float y) {
-		mRenderer.requestColorPickingTexture(new ColorPickerInfo(x, y, this));
+		mRenderer.getCurrentScene().requestColorPickingTexture(new ColorPickerInfo(x, y, this));
 	}
 
 	public void createColorPickingTexture(ColorPickerInfo pickerInfo) {


### PR DESCRIPTION
### The Addition

As part of the development of scene graphs (#535), I have added two major features which I feel are mature enough to be brought into the master branch for people to start looking at and using to flush out some bugs. These features are:
- A task queue: Adding/Removing/Replacing objects such as Animations, Cameras, Children, and Plugins are now asynchronously thread safe and managed by the render thread.
  - A new class, `RajawaliScene` has been added. This class is now responsible for handling the render calls and addition, removal and replacement of things like Animations, Cameras, Children, Plugins and eventually Lights. 
  - `RajawaliRenderer` is now responsible only for managing scenes and and OpenGL context.
  - Helper methods exist and a default scene is initialized automatically for you so you can continue using addChild() and similar calls directly in `RajawaliRenderer.initScene()` if your needs are simple or you don't want to do much code changing.
### Caveats
- The scene will eventually contain a scene graph and currently has incomplete support for it so I advise against trying to use a graph, but a brute force scene works great.
- The FBX import example does not work yet.
- Currently, enabling fog turns it on for all cameras in all scenes.
- `IPostProcessingFilter` does not work, nor is it even supported by `RajawaliRenderer`.
