### PR TITLE
Adds initial support for OpenGL ES 3.0

### DIFF
--- a/project.properties
+++ b/project.properties
@@ -8,5 +8,5 @@
 # project structure.
 
 # Project target.
-target=android-17
+target=android-18
 android.library=true

--- a/src/rajawali/renderer/RajawaliRenderer.java
+++ b/src/rajawali/renderer/RajawaliRenderer.java
@@ -5,8 +5,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Timer;
-import java.util.TimerTask;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -74,6 +72,10 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 	protected static boolean mFogEnabled; //Is camera fog enabled?
 	protected static int mMaxLights = 1; //How many lights max?
 	protected int mLastReportedGLError = 0; // Keep track of the last reported OpenGL error
+	
+	//In case we cannot parse the version number, assume OpenGL ES 2.0
+	protected int mGLES_Major_Version = 2; //The GL ES major version of the surface
+	protected int mGLES_Minor_Version = 0; //The GL ES minor version of the surface
 
 	/**
 	 * Scene caching stores all textures and relevant OpenGL-specific
@@ -499,6 +501,16 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 	public void onSurfaceCreated(GL10 gl, EGLConfig config) {
 		RajLog.setGL10(gl);
 		Capabilities.getInstance();
+		
+		String[] versionString = (gl.glGetString(GL10.GL_VERSION)).split(" ");
+		if (versionString.length >= 3) {
+			String[] versionParts = versionString[2].split(".");
+			if (versionParts.length == 2) {
+				mGLES_Major_Version = Integer.parseInt(versionParts[0]);
+				mGLES_Minor_Version = Integer.parseInt(versionParts[1]);
+			}
+		}
+		
 		supportsUIntBuffers = gl.glGetString(GL10.GL_EXTENSIONS).indexOf("GL_OES_element_index_uint") > -1;
 
 		//GLES20.glFrontFace(GLES20.GL_CCW);
@@ -1278,6 +1290,24 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 		EGL10 egl = (EGL10)EGLContext.getEGL();
 		EGLContext eglContext = egl.eglGetCurrentContext();
 		return eglContext != EGL10.EGL_NO_CONTEXT;
+	}
+	
+	/**
+	 * Fetches the Open GL ES major version of the EGL surface.
+	 * 
+	 * @return int containing the major version number.
+	 */
+	public int getGLMajorVersion() {
+		return mGLES_Major_Version;
+	}
+	
+	/**
+	 * Fetches the Open GL ES minor version of the EGL surface.
+	 * 
+	 * @return int containing the minor version number.
+	 */
+	public int getGLMinorVersion() {
+		return mGLES_Minor_Version;
 	}
 
 	public void setUsesCoverageAa(boolean usesCoverageAa) {


### PR DESCRIPTION
This doesn't add much but it prepares the way for Open GL ES 3.0 features.
- Updated library properties to support Android 4.3 API 18
- Adds fields to `RajawaliRenderer` containing the OpenGL major and minor version numbers for the EGL surface
- Added code to `RajawaliRenderer#onSurfaceCreated(GL10, EGLConfig)` to determine the EGL surface version
- Adds public getter methods to `RajawaliRenderer` to retrieve the major and minor version numbers

Note that nothing else is needed here. Due to the backwards compatibility of OpenGL ES 3.0 with 2.0, in Android when you request a 2.0 version EGL surface, you are automatically given a 3.0 surface if the device supports it.
