### PR TITLE
Fixed U order in Sphere

### DIFF
--- a/src/rajawali/primitives/Sphere.java
+++ b/src/rajawali/primitives/Sphere.java
@@ -128,8 +128,8 @@ public class Sphere extends BaseObject3D {
 
 			numUvs = 0;
 			for (j = 0; j <= mSegmentsH; ++j) {
-				for (i = 0; i <= mSegmentsW; ++i) {
-					textureCoords[numUvs++] = -(float) i / mSegmentsW;
+				for (i = mSegmentsW; i >= 0; --i) {
+					textureCoords[numUvs++] = (float) i / mSegmentsW;
 					textureCoords[numUvs++] = (float) j / mSegmentsH;
 				}
 			}


### PR DESCRIPTION
The order of U was backwards and was set as negative previously to fix which was basically a hack. This adversely impacted the TextureAtlas code. The U is now properly reversed.
