### PR TITLE
Fix setAtlasTile method to properly update UVs

### DIFF
--- a/src/rajawali/BaseObject3D.java
+++ b/src/rajawali/BaseObject3D.java
@@ -848,6 +848,8 @@ public class BaseObject3D extends ATransformable3D implements Comparable<BaseObj
 				uvOut = (uvIn * (tile.height/atlas.getHeight())) + tile.y/atlas.getHeight();
 			fb.put(i, uvOut);
 		}
+		mGeometry.changeBufferData(mGeometry.mTexCoordBufferInfo, fb, 0);
+
 	}
 	
 	public void destroy() {


### PR DESCRIPTION
This fixes a method used by devs leveraging that TextureAtlas with primitives. The UVs were being properly scaled/offset, but the result was not always applied because of poor timing. This forces the update of the UVs in all cases.
