### PR TITLE
fix shadervar return type error

### DIFF
--- a/src/rajawali/materials/shaders/AShaderBase.java
+++ b/src/rajawali/materials/shaders/AShaderBase.java
@@ -198,7 +198,7 @@ public abstract class AShaderBase {
 	{
 		ShaderVar out = null;
 		
-		if(left == right)
+		if(left != right)
 			out = getInstanceForDataType(left);
 		else if(left == DataType.IVEC4 || right == DataType.IVEC4)
 			out = getInstanceForDataType(DataType.IVEC4);


### PR DESCRIPTION
about the issue #1312 

in the function, i don't think the `if (left == right)` is right. Or change the function like this:

```
protected ShaderVar getReturnTypeForOperation(DataType left, DataType right)
{
    ShaderVar out = null;

    if (left == right)
        out = getInstanceForDataType(left);
    else
        out = getInstanceForDataType(DataType.INT);

    return out;
}
```
