### PR TITLE
mIsFirstStart initialization

### DIFF
--- a/src/rajawali/animation/Animation.java
+++ b/src/rajawali/animation/Animation.java
@@ -33,7 +33,7 @@ public abstract class Animation extends Playable {
 	protected int mNumRepeat;
 	protected boolean mIsStarted;
 
-	private boolean mIsFirstStart;
+	private boolean mIsFirstStart = true;
 
 	public Animation() {
 		mAnimationListeners = new ArrayList<IAnimationListener>();


### PR DESCRIPTION
Animation.mIsFirstStart should be initialized as true
to fixed bugs like:

public boolean isFirstStart() {
return mIsFirstStart;
}  always return false.

scale animation always scaled from 0.
