### PR TITLE
Allows for lazy VBO creation

### DIFF
--- a/rajawali/src/main/java/rajawali/Camera.java
+++ b/rajawali/src/main/java/rajawali/Camera.java
@@ -12,6 +12,9 @@
  */
 package rajawali;
 
+import android.graphics.Color;
+import android.opengl.GLES20;
+
 import java.nio.FloatBuffer;
 import java.util.Stack;
 
@@ -23,8 +26,6 @@ import rajawali.math.Quaternion;
 import rajawali.math.vector.Vector3;
 import rajawali.primitives.Line3D;
 import rajawali.renderer.AFrameTask;
-import android.graphics.Color;
-import android.opengl.GLES20;
 
 public class Camera extends ATransformable3D {
 	protected final Object mFrustumLock = new Object();	

--- a/rajawali/src/main/java/rajawali/animation/mesh/SkeletalAnimationObject3D.java
+++ b/rajawali/src/main/java/rajawali/animation/mesh/SkeletalAnimationObject3D.java
@@ -12,6 +12,19 @@
  */
 package rajawali.animation.mesh;
 
+import android.opengl.GLES20;
+import android.os.SystemClock;
+import android.view.animation.AccelerateDecelerateInterpolator;
+import android.view.animation.AccelerateInterpolator;
+import android.view.animation.AnticipateInterpolator;
+import android.view.animation.AnticipateOvershootInterpolator;
+import android.view.animation.BounceInterpolator;
+import android.view.animation.CycleInterpolator;
+import android.view.animation.DecelerateInterpolator;
+import android.view.animation.Interpolator;
+import android.view.animation.LinearInterpolator;
+import android.view.animation.OvershootInterpolator;
+
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.DoubleBuffer;
@@ -26,18 +39,6 @@ import rajawali.math.Matrix;
 import rajawali.math.Matrix4;
 import rajawali.math.vector.Vector3;
 import rajawali.util.RajLog;
-import android.opengl.GLES20;
-import android.os.SystemClock;
-import android.view.animation.AccelerateDecelerateInterpolator;
-import android.view.animation.AccelerateInterpolator;
-import android.view.animation.AnticipateInterpolator;
-import android.view.animation.AnticipateOvershootInterpolator;
-import android.view.animation.BounceInterpolator;
-import android.view.animation.CycleInterpolator;
-import android.view.animation.DecelerateInterpolator;
-import android.view.animation.Interpolator;
-import android.view.animation.LinearInterpolator;
-import android.view.animation.OvershootInterpolator;
 
 public class SkeletalAnimationObject3D extends AAnimationObject3D {
 	private SkeletonJoint[] mJoints;
@@ -263,7 +264,7 @@ public class SkeletalAnimationObject3D extends AAnimationObject3D {
 	}
 
 	@Override
-	public void render(Camera camera, final Matrix4 projMatrix, final Matrix4 vMatrix, 
+	public void render(Camera camera, final Matrix4 projMatrix, final Matrix4 vMatrix,
 			final Matrix4 parentMatrix, Material sceneMaterial) {
 		setShaderParams(camera);
 		super.render(camera, projMatrix, vMatrix, parentMatrix, sceneMaterial);

--- a/rajawali/src/main/java/rajawali/bounds/BoundingBox.java
+++ b/rajawali/src/main/java/rajawali/bounds/BoundingBox.java
@@ -12,6 +12,8 @@
  */
 package rajawali.bounds;
 
+import android.opengl.GLES20;
+
 import java.nio.FloatBuffer;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -22,7 +24,6 @@ import rajawali.materials.Material;
 import rajawali.math.Matrix4;
 import rajawali.math.vector.Vector3;
 import rajawali.primitives.Cube;
-import android.opengl.GLES20;
 
 public class BoundingBox implements IBoundingVolume {
 	protected Geometry3D mGeometry;

--- a/rajawali/src/main/java/rajawali/bounds/BoundingSphere.java
+++ b/rajawali/src/main/java/rajawali/bounds/BoundingSphere.java
@@ -12,6 +12,8 @@
  */
 package rajawali.bounds;
 
+import android.opengl.GLES20;
+
 import java.nio.FloatBuffer;
 
 import rajawali.Camera;
@@ -21,7 +23,6 @@ import rajawali.materials.Material;
 import rajawali.math.Matrix4;
 import rajawali.math.vector.Vector3;
 import rajawali.primitives.Sphere;
-import android.opengl.GLES20;
 
 public class BoundingSphere implements IBoundingVolume {
 	protected Geometry3D mGeometry;

--- a/rajawali/src/main/java/rajawali/parser/Loader3DSMax.java
+++ b/rajawali/src/main/java/rajawali/parser/Loader3DSMax.java
@@ -261,7 +261,7 @@ public class Loader3DSMax extends AMeshLoader {
 			}
 
 			Object3D targetObj = new Object3D(mObjNames.get(j));
-			targetObj.setData(aVertices, aNormals, aTexCoords, null, aIndices);
+			targetObj.setData(aVertices, aNormals, aTexCoords, null, aIndices, false);
 			// -- diffuse material with random color. for now.
 			Material material = new Material();
 			material.setDiffuseMethod(new DiffuseMethod.Lambert());

--- a/rajawali/src/main/java/rajawali/parser/LoaderMD2.java
+++ b/rajawali/src/main/java/rajawali/parser/LoaderMD2.java
@@ -12,6 +12,10 @@
  */
 package rajawali.parser;
 
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+
 import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -34,9 +38,6 @@ import rajawali.materials.textures.TextureManager;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.LittleEndianDataInputStream;
 import rajawali.util.RajLog;
-import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 
 public class LoaderMD2 extends AMeshLoader implements IAnimatedMeshLoader {
 
@@ -115,7 +116,7 @@ public class LoaderMD2 extends AMeshLoader implements IAnimatedMeshLoader {
 			material.addPlugin(new VertexAnimationMaterialPlugin());
 			mObject.getGeometry().copyFromGeometry3D(firstFrame.getGeometry());
 			mObject.setData(firstFrame.getGeometry().getVertexBufferInfo(), firstFrame.getGeometry()
-					.getNormalBufferInfo(), mTextureCoords, null, mIndices);
+					.getNormalBufferInfo(), mTextureCoords, null, mIndices, false);
 			mObject.setMaterial(material);
 			
 			mObject.setColor(0xffffffff);

--- a/rajawali/src/main/java/rajawali/parser/LoaderOBJ.java
+++ b/rajawali/src/main/java/rajawali/parser/LoaderOBJ.java
@@ -12,23 +12,38 @@
  */
 package rajawali.parser;
 
-import java.io.*;
+import android.content.res.Resources;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.lang.reflect.Field;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+import java.util.StringTokenizer;
 
 import rajawali.Object3D;
 import rajawali.materials.Material;
 import rajawali.materials.methods.DiffuseMethod;
 import rajawali.materials.methods.SpecularMethod;
-import rajawali.materials.textures.*;
 import rajawali.materials.textures.ATexture.TextureException;
+import rajawali.materials.textures.Etc1Texture;
+import rajawali.materials.textures.NormalMapTexture;
+import rajawali.materials.textures.SpecularMapTexture;
+import rajawali.materials.textures.Texture;
+import rajawali.materials.textures.TextureManager;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.RajLog;
 import rajawali.wallpaper.Wallpaper;
-import android.content.res.Resources;
-import android.graphics.BitmapFactory;
-import android.graphics.Color;
-import android.util.Log;
 
 /**
  * The most important thing is that the model should be triangulated. Rajawali doesn�t accept quads, only tris. In Blender, this is an option you can select in the exporter. In a program like MeshLab, this is done automatically.
@@ -333,7 +348,7 @@ public class LoaderOBJ extends AMeshLoader {
 				aNormals[ni+2] = normals.get(normalIndex + 2);
 			}
 			
-			oid.targetObj.setData(aVertices, aNormals, aTexCoords, aColors, aIndices);
+			oid.targetObj.setData(aVertices, aNormals, aTexCoords, aColors, aIndices, false);
 			try {
 				matLib.setMaterial(oid.targetObj, oid.materialName);
 			} catch(TextureException tme) {

--- a/rajawali/src/main/java/rajawali/parser/LoaderSTL.java
+++ b/rajawali/src/main/java/rajawali/parser/LoaderSTL.java
@@ -12,6 +12,9 @@
  */
 package rajawali.parser;
 
+import android.content.res.Resources;
+import android.content.res.Resources.NotFoundException;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -24,8 +27,6 @@ import java.util.List;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.LittleEndianDataInputStream;
 import rajawali.util.RajLog;
-import android.content.res.Resources;
-import android.content.res.Resources.NotFoundException;
 
 /**
  * STL Parser written using the ASCII format as describe on Wikipedia.
@@ -206,7 +207,7 @@ public class LoaderSTL extends AMeshLoader {
 		for (i = 0; i < indicesArr.length; i++)
 			indicesArr[i] = i;
 
-		mRootObject.setData(verticesArr, normalsArr, null, null, indicesArr);
+		mRootObject.setData(verticesArr, normalsArr, null, null, indicesArr, false);
 	}
 
 	/**
@@ -262,7 +263,7 @@ public class LoaderSTL extends AMeshLoader {
 			dis.skip(2);
 		}
 
-		mRootObject.setData(verticesArr, normalsArr, null, null, indicesArr);
+		mRootObject.setData(verticesArr, normalsArr, null, null, indicesArr, false);
 	}
 
 	/**

--- a/rajawali/src/main/java/rajawali/parser/awd/BlockTriangleGeometry.java
+++ b/rajawali/src/main/java/rajawali/parser/awd/BlockTriangleGeometry.java
@@ -1,12 +1,13 @@
 package rajawali.parser.awd;
 
+import android.util.SparseArray;
+
 import org.apache.http.ParseException;
 
 import rajawali.Object3D;
 import rajawali.parser.LoaderAWD.AWDLittleEndianDataInputStream;
 import rajawali.parser.LoaderAWD.BlockHeader;
 import rajawali.util.RajLog;
-import android.util.SparseArray;
 
 /**
  * The TriangleGeometry block describes a single mesh of an AWD file. Multiple TriangleGeometry blocks may exists in a
@@ -145,7 +146,7 @@ public class BlockTriangleGeometry extends ABaseObjectBlockParser {
 
 			// FIXME This should be combining sub geometry not creating objects
 			mBaseObjects[parsedSub] = new Object3D();
-			mBaseObjects[parsedSub].setData(vertices, normals, uvs, null, indices);
+			mBaseObjects[parsedSub].setData(vertices, normals, uvs, null, indices, false);
 		}
 
 		dis.readUserAttributes(null);

--- a/rajawali/src/main/java/rajawali/parser/fbx/LoaderFBX.java
+++ b/rajawali/src/main/java/rajawali/parser/fbx/LoaderFBX.java
@@ -12,6 +12,10 @@
  */
 package rajawali.parser.fbx;
 
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.Color;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -50,9 +54,6 @@ import rajawali.parser.fbx.FBXValues.Objects.FBXMaterial;
 import rajawali.parser.fbx.FBXValues.Objects.Model;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.RajLog;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.Color;
 public class LoaderFBX extends AMeshLoader {
 	private static final char COMMENT = ';';
 	private static final String OBJECT_TYPE = "ObjectType:";
@@ -385,7 +386,8 @@ public class LoaderFBX extends AMeshLoader {
 			}
 		}
 		
-		o.setData(convertFloats(vertices), convertFloats(normals), hasUVs ? convertFloats(uvs) : null, null, convertIntegers(indices));
+		o.setData(convertFloats(vertices), convertFloats(normals), hasUVs ? convertFloats(uvs) : null, null,
+            convertIntegers(indices), false);
 		
 		vertices.clear();
 		vertices = null;

--- a/rajawali/src/main/java/rajawali/parser/md5/LoaderMD5Mesh.java
+++ b/rajawali/src/main/java/rajawali/parser/md5/LoaderMD5Mesh.java
@@ -12,6 +12,9 @@
  */
 package rajawali.parser.md5;
 
+import android.content.res.Resources;
+import android.opengl.GLES20;
+
 import java.io.BufferedReader;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -39,8 +42,6 @@ import rajawali.parser.IAnimatedMeshLoader;
 import rajawali.parser.ParsingException;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.RajLog;
-import android.content.res.Resources;
-import android.opengl.GLES20;
 
 public class LoaderMD5Mesh extends AMeshLoader implements IAnimatedMeshLoader {
 
@@ -424,8 +425,8 @@ public class LoaderMD5Mesh extends AMeshLoader implements IAnimatedMeshLoader {
 					mesh.normals, GLES20.GL_STREAM_DRAW,
 					mesh.textureCoordinates, GLES20.GL_STATIC_DRAW,
 					null, GLES20.GL_STATIC_DRAW,
-					mesh.indices, GLES20.GL_STATIC_DRAW
-					);
+					mesh.indices, GLES20.GL_STATIC_DRAW,
+					false);
 			o.setMaxBoneWeightsPerVertex(mesh.maxBoneWeightsPerVertex);
 			o.setSkeletonMeshData(mesh.numVertices, mesh.boneVertices, mesh.numWeights, mesh.boneWeights);
 			o.setName("MD5Mesh_" + i);

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/CopyToNewRenderTargetPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/CopyToNewRenderTargetPass.java
@@ -15,6 +15,8 @@ package rajawali.postprocessing.passes;
 import android.graphics.Bitmap.Config;
 import android.opengl.GLES20;
 
+import javax.microedition.khronos.opengles.GL10;
+
 import rajawali.framework.R;
 import rajawali.materials.textures.ATexture.FilterType;
 import rajawali.materials.textures.ATexture.WrapType;

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/DepthPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/DepthPass.java
@@ -1,6 +1,9 @@
 package rajawali.postprocessing.passes;
 
 import android.opengl.GLES20;
+
+import javax.microedition.khronos.opengles.GL10;
+
 import rajawali.Camera;
 import rajawali.materials.Material;
 import rajawali.materials.plugins.DepthMaterialPlugin;

--- a/rajawali/src/main/java/rajawali/postprocessing/passes/EffectPass.java
+++ b/rajawali/src/main/java/rajawali/postprocessing/passes/EffectPass.java
@@ -12,6 +12,8 @@
  */
 package rajawali.postprocessing.passes;
 
+import javax.microedition.khronos.opengles.GL10;
+
 import rajawali.materials.Material;
 import rajawali.materials.shaders.FragmentShader;
 import rajawali.materials.shaders.VertexShader;

--- a/rajawali/src/main/java/rajawali/primitives/Cube.java
+++ b/rajawali/src/main/java/rajawali/primitives/Cube.java
@@ -42,7 +42,7 @@ public class Cube extends Object3D {
 	 * @param size		The size of the cube.
 	 */
 	public Cube(float size) {
-		this(size, false, false, true, false);
+		this(size, false, false, true, false, true);
 	}
 
 	/**
@@ -53,7 +53,7 @@ public class Cube extends Object3D {
 	 * 						be inverted.
 	 */
 	public Cube(float size, boolean isSkybox) {
-		this(size, isSkybox, true, true, false);
+		this(size, isSkybox, true, true, false, true);
 	}
 	
 	/**
@@ -67,7 +67,7 @@ public class Cube extends Object3D {
 	 */
 	public Cube(float size, boolean isSkybox, boolean hasCubemapTexture)
 	{
-		this(size, isSkybox, hasCubemapTexture, true, false);
+		this(size, isSkybox, hasCubemapTexture, true, false, true);
 	}
 
 	/**
@@ -80,19 +80,20 @@ public class Cube extends Object3D {
 	 * 									single texture.
 	 * @param createTextureCoordinates	A boolean that indicates whether the texture coordinates should be calculated or not.
 	 * @param createVertexColorBuffer	A boolean that indicates whether a vertex color buffer should be created or not.
+     * @param createVBOs                A boolean that indicates whether the VBOs should be created immediately.
 	 */
 	public Cube(float size, boolean isSkybox, boolean hasCubemapTexture, boolean createTextureCoordinates,
-			boolean createVertexColorBuffer) {
+			boolean createVertexColorBuffer, boolean createVBOs) {
 		super();
 		mIsSkybox = isSkybox;
 		mSize = size;
 		mHasCubemapTexture = hasCubemapTexture;
 		mCreateTextureCoords = createTextureCoordinates;
 		mCreateVertexColorBuffer = createVertexColorBuffer;
-		init();
+		init(createVBOs);
 	}
 
-	private void init()
+	private void init(boolean createVBOs)
 	{
 		float halfSize = mSize * .5f;
 		float[] vertices = {
@@ -185,7 +186,7 @@ public class Cube extends Object3D {
 		};
 
 		setData(vertices, normals, mIsSkybox || mHasCubemapTexture ? skyboxTextureCoords : textureCoords, colors,
-				mIsSkybox && mHasCubemapTexture ? skyboxIndices : indices);
+				mIsSkybox && mHasCubemapTexture ? skyboxIndices : indices, createVBOs);
 		
 		vertices = null;
 		normals = null;

--- a/rajawali/src/main/java/rajawali/primitives/Line3D.java
+++ b/rajawali/src/main/java/rajawali/primitives/Line3D.java
@@ -12,12 +12,13 @@
  */
 package rajawali.primitives;
 
+import android.graphics.Color;
+import android.opengl.GLES20;
+
 import java.util.Stack;
 
 import rajawali.Object3D;
 import rajawali.math.vector.Vector3;
-import android.graphics.Color;
-import android.opengl.GLES20;
 
 /**
  * The Line3D takes a list of Vector3 points, thickness and a color.
@@ -81,22 +82,33 @@ public class Line3D extends Object3D {
 	 * @param thickness
 	 * @param colors
 	 */
-	public Line3D(Stack<Vector3> points, float thickness, int[] colors)
-	{
-		super();
-		mPoints = points;
-		mThickness = thickness;
-		mColors = colors;
-		if(colors != null && colors.length != points.size())
-			throw new RuntimeException("The number of line points and colors is not the same.");
-		init();
+	public Line3D(Stack<Vector3> points, float thickness, int[] colors) {
+		this(points, thickness, colors, true);
 	}
+
+    /**
+     * Creates a line primitive with a specified color for each point.
+     *
+     * @param points
+     * @param thickness
+     * @param colors
+     * @param createVBOs
+     */
+    public Line3D(Stack<Vector3> points, float thickness, int[] colors, boolean createVBOs) {
+        super();
+        mPoints = points;
+        mThickness = thickness;
+        mColors = colors;
+        if (colors != null && colors.length != points.size())
+            throw new RuntimeException("The number of line points and colors is not the same.");
+        init(createVBOs);
+    }
 	
 	public Vector3 getPoint(int point) {
 		return mPoints.get(point);
 	}
 	
-	private void init() {
+	private void init(boolean createVBOs) {
 		setDoubleSided(true);
 		setDrawingMode(GLES20.GL_LINE_STRIP);
 		
@@ -130,7 +142,7 @@ public class Line3D extends Object3D {
 			}
 		}
 		
-		setData(vertices, null, null, colors, indices);
+		setData(vertices, null, null, colors, indices, createVBOs);
 		
 		vertices = null;
 		colors = null;

--- a/rajawali/src/main/java/rajawali/primitives/NPrism.java
+++ b/rajawali/src/main/java/rajawali/primitives/NPrism.java
@@ -58,8 +58,23 @@ public class NPrism extends Object3D {
 	 * @param height Double the height of the prism.
 	 */
 	public NPrism(int sides, double radiusTop, double radiusBase, double height) {
-		this(sides, radiusTop, radiusBase, 0.0, height);
+		this(sides, radiusTop, radiusBase, 0.0, height, true);
 	}
+
+    /**
+     * Creates a frustum like prism with elliptical base rather than circular.
+     * The major axis is equivalent to the radius specified and the minor axis
+     * is computed from the eccentricity.
+     *
+     * @param sides        Integer number of sides to the prism.
+     * @param radiusTop    Double the radius of the top.
+     * @param radiusBase   Double the radius of the base.
+     * @param eccentricity Double the eccentricity of the ellipse.
+     * @param height       Double the height of the prism.
+     */
+    public NPrism(int sides, double radiusTop, double radiusBase, double eccentricity, double height) {
+        this(sides, radiusTop, radiusBase, eccentricity, height, true);
+    }
 	
 	/**
 	 * Creates a frustum like prism with elliptical base rather than circular. 
@@ -71,8 +86,9 @@ public class NPrism extends Object3D {
 	 * @param radiusBase Double the radius of the base.
 	 * @param eccentricity Double the eccentricity of the ellipse.
 	 * @param height Double the height of the prism.
+     * @param createVBOs Boolean If true, the VBOs are created immediately.
 	 */
-	public NPrism(int sides, double radiusTop, double radiusBase, double eccentricity, double height) {
+	public NPrism(int sides, double radiusTop, double radiusBase, double eccentricity, double height, boolean createVBOs) {
 		if (sides < 3) throw new IllegalArgumentException("Prisms must have at least 3 sides!");
 		if ((eccentricity < 0) || (eccentricity >= 1)) throw new IllegalArgumentException("Eccentricity must be in the range [0,1)");
 		mSideCount = sides;
@@ -82,14 +98,14 @@ public class NPrism extends Object3D {
 		mRadiusBase = radiusBase;
 		mMinorBase = calculateMinorAxis(mRadiusBase);
 		mHeight = height;
-		init();
+		init(createVBOs);
 	}
 	
 	protected double calculateMinorAxis(double major) {
 		return Math.sqrt(Math.pow(major, 2.0)*(1 - Math.pow(mEccentricity, 2.0)));
 	}
 
-	protected void init() {
+	protected void init(boolean createVBOs) {
 		int vertex_count = 6*mSideCount + 2;
 		int tri_count = 4*mSideCount;
 		int top_center_index = 3*vertex_count - 6;
@@ -274,6 +290,6 @@ public class NPrism extends Object3D {
 			colors[i] = 1.0f;
 		}
 
-		setData(vertices, normals, texture, colors, indices);
+		setData(vertices, normals, texture, colors, indices, createVBOs);
 	}
 }

--- a/rajawali/src/main/java/rajawali/primitives/Plane.java
+++ b/rajawali/src/main/java/rajawali/primitives/Plane.java
@@ -139,7 +139,23 @@ public class Plane extends Object3D {
 		this(width, height, segmentsW, segmentsH, upAxis, createTextureCoordinates, createVertexColorBuffer, 1);
 	}
 
-	
+    /**
+     * Creates a plane primitive.
+     *
+     * @param width                    The plane width
+     * @param height                   The plane height
+     * @param segmentsW                The number of vertical segments
+     * @param segmentsH                The number of horizontal segments
+     * @param upAxis                   The up axis. Choose Axis.Y for a ground plane and Axis.Z for a camera facing plane.
+     * @param createTextureCoordinates A boolean that indicates whether the texture coordinates should be calculated or not.
+     * @param createVertexColorBuffer  A boolean that indicates whether a vertex color buffer should be created or not.
+     * @param numTextureTiles          The number of texture tiles. If more than 1 the texture will be repeat by n times.
+     */
+    public Plane(float width, float height, int segmentsW, int segmentsH, Axis upAxis, boolean createTextureCoordinates,
+                 boolean createVertexColorBuffer, int numTextureTiles) {
+        this(width, height, segmentsW, segmentsH, upAxis, createTextureCoordinates, createVertexColorBuffer, numTextureTiles, true);
+    }
+
 	/**
 	 * Creates a plane primitive.
 	 * 
@@ -159,9 +175,11 @@ public class Plane extends Object3D {
 	 *            A boolean that indicates whether a vertex color buffer should be created or not.
 	 * @param numTextureTiles
 	 * 			  The number of texture tiles. If more than 1 the texture will be repeat by n times.
+     * @param createVBOs
+     *            A boolean that indicates whether the VBOs should be created immediately.
 	 */
 	public Plane(float width, float height, int segmentsW, int segmentsH, Axis upAxis, boolean createTextureCoordinates,
-			boolean createVertexColorBuffer, int numTextureTiles) {
+			boolean createVertexColorBuffer, int numTextureTiles, boolean createVBOs) {
 		super();
 		mWidth = width;
 		mHeight = height;
@@ -171,10 +189,10 @@ public class Plane extends Object3D {
 		mCreateTextureCoords = createTextureCoordinates;
 		mCreateVertexColorBuffer = createVertexColorBuffer;
 		mNumTextureTiles = numTextureTiles;
-		init();
+		init(createVBOs);
 	}
 
-	private void init() {
+	private void init(boolean createVBOs) {
 		int i, j;
 		int numVertices = (mSegmentsW + 1) * (mSegmentsH + 1);
 		float[] vertices = new float[numVertices * 3];
@@ -259,7 +277,7 @@ public class Plane extends Object3D {
 			}
 		}
 
-		setData(vertices, normals, textureCoords, colors, indices);
+		setData(vertices, normals, textureCoords, colors, indices, createVBOs);
 		
 		vertices = null;
 		normals = null;

--- a/rajawali/src/main/java/rajawali/primitives/PointSprite.java
+++ b/rajawali/src/main/java/rajawali/primitives/PointSprite.java
@@ -10,9 +10,13 @@ public class PointSprite extends Plane {
 	public PointSprite(float width, float height) {
 		super(width, height, 1, 1, Axis.Z);
 	}
+
+    public PointSprite(float width, float height, boolean createVBOs) {
+        super(width, height, 1, 1, Axis.Z, true, false, 1, createVBOs);
+    }
 	
 	@Override
-	public void render(Camera camera, final Matrix4 vpMatrix, final Matrix4 projMatrix, final Matrix4 vMatrix, 
+	public void render(Camera camera, final Matrix4 vpMatrix, final Matrix4 projMatrix, final Matrix4 vMatrix,
 			final Matrix4 parentMatrix, Material sceneMaterial) {
 		setLookAt(camera.getPosition());		
 		super.render(camera, vpMatrix, projMatrix, vMatrix, parentMatrix, sceneMaterial);

--- a/rajawali/src/main/java/rajawali/primitives/RectangularPrism.java
+++ b/rajawali/src/main/java/rajawali/primitives/RectangularPrism.java
@@ -72,6 +72,22 @@ public class RectangularPrism extends Object3D {
 		this(width, height, depth, hasCubemapTexture, true, false);
 	}
 
+    /**
+     * Creates a cube primitive.
+     *
+     * @param width                    The width of the prism.
+     * @param height                   The height of the prism.
+     * @param depth                    The depth of the prism.
+     * @param hasCubemapTexture        A boolean that indicates a cube map texture will be used (6 textures) or a regular
+     *                                 single texture.
+     * @param createTextureCoordinates A boolean that indicates whether the texture coordinates should be calculated or not.
+     * @param createVertexColorBuffer  A boolean that indicates whether a vertex color buffer should be created or not.
+     */
+    public RectangularPrism(float width, float height, float depth, boolean hasCubemapTexture,
+                            boolean createTextureCoordinates, boolean createVertexColorBuffer) {
+        this(width, height, depth, hasCubemapTexture, createTextureCoordinates, createVertexColorBuffer, true);
+    }
+
 	/**
 	 * Creates a cube primitive.
 	 *
@@ -82,9 +98,10 @@ public class RectangularPrism extends Object3D {
 	 * 									single texture.
 	 * @param createTextureCoordinates	A boolean that indicates whether the texture coordinates should be calculated or not.
 	 * @param createVertexColorBuffer	A boolean that indicates whether a vertex color buffer should be created or not.
+     * @param createVBOs                A boolean that indicates whether the VBOs should be created imediately or not.
 	 */
 	public RectangularPrism(float width, float height, float depth, boolean hasCubemapTexture,
-							boolean createTextureCoordinates, boolean createVertexColorBuffer) {
+							boolean createTextureCoordinates, boolean createVertexColorBuffer, boolean createVBOs) {
 		super();
 		mWidth = width;
 		mHeight = height;
@@ -92,10 +109,10 @@ public class RectangularPrism extends Object3D {
 		mHasCubemapTexture = hasCubemapTexture;
 		mCreateTextureCoords = createTextureCoordinates;
 		mCreateVertexColorBuffer = createVertexColorBuffer;
-		init();
+		init(createVBOs);
 	}
 
-	private void init()
+	private void init(boolean createVBOs)
 	{
 		float halfWidth = mWidth * .5f;
 		float halfHeight = mHeight * .5f;
@@ -170,7 +187,7 @@ public class RectangularPrism extends Object3D {
 				20, 21, 22, 20, 22, 23,
 		};
 
-		setData(vertices, normals, textureCoords, colors, indices);
+		setData(vertices, normals, textureCoords, colors, indices, createVBOs);
 		
 		vertices = null;
 		normals = null;

--- a/rajawali/src/main/java/rajawali/primitives/ScreenQuad.java
+++ b/rajawali/src/main/java/rajawali/primitives/ScreenQuad.java
@@ -12,13 +12,12 @@
  */
 package rajawali.primitives;
 
-import rajawali.Object3D;
 import rajawali.Camera;
 import rajawali.Camera2D;
+import rajawali.Object3D;
 import rajawali.materials.Material;
 import rajawali.math.Matrix4;
 import rajawali.postprocessing.passes.EffectPass;
-import rajawali.util.ObjectColorPicker.ColorPickerInfo;
 
 /**
  * A screen quad is a plane that covers the whole screen. When used in conjunction with
@@ -55,17 +54,24 @@ public class ScreenQuad extends Object3D {
 	private Camera2D mCamera;
 	private Matrix4 mVPMatrix;
 	private EffectPass mEffectPass;
-	
+
+    /**
+     * Creates a new ScreenQuad.
+     */
+    public ScreenQuad() {
+        this(true);
+    }
+
 	/**
 	 * Creates a new ScreenQuad.
 	 */
-	public ScreenQuad()
+	public ScreenQuad(boolean createVBOs)
 	{
 		super();
-		init();
+		init(createVBOs);
 	}
 
-	private void init() {
+	private void init(boolean createVBOs) {
 		mCamera = new Camera2D();
 		mCamera.setProjectionMatrix(0, 0);
 		mVPMatrix = new Matrix4();
@@ -87,7 +93,7 @@ public class ScreenQuad extends Object3D {
 		};
 		int[] indices = new int[] { 0, 2, 1, 0, 3, 2 };
 		
-		setData(vertices, normals, textureCoords, null, indices);
+		setData(vertices, normals, textureCoords, null, indices, createVBOs);
 		
 		vertices = null;
 		normals = null;

--- a/rajawali/src/main/java/rajawali/primitives/Sphere.java
+++ b/rajawali/src/main/java/rajawali/primitives/Sphere.java
@@ -50,7 +50,7 @@ public class Sphere extends Object3D {
 	 *            The number of horizontal segments
 	 */
 	public Sphere(float radius, int segmentsW, int segmentsH) {
-		this(radius, segmentsW, segmentsH, true, false);
+		this(radius, segmentsW, segmentsH, true, false, true);
 	}
 
 	/**
@@ -66,19 +66,21 @@ public class Sphere extends Object3D {
 	 *            A boolean that indicates whether the texture coordinates should be calculated or not.
 	 * @param createVertexColorBuffer
 	 *            A boolean that indicates whether a vertex color buffer should be created or not.
+     * @param createVertexColorBuffer
+     *            A boolean that indicates whether the VBOs should be created immediately.
 	 */
 	public Sphere(float radius, int segmentsW, int segmentsH, boolean createTextureCoordinates,
-			boolean createVertexColorBuffer) {
+			boolean createVertexColorBuffer, boolean createVBOs) {
 		super();
 		mRadius = radius;
 		mSegmentsW = segmentsW;
 		mSegmentsH = segmentsH;
 		mCreateTextureCoords = createTextureCoordinates;
 		mCreateVertexColorBuffer = createVertexColorBuffer;
-		init();
+		init(createVBOs);
 	}
 
-	protected void init() {
+	protected void init(boolean createVBOs) {
 		int numVertices = (mSegmentsW + 1) * (mSegmentsH + 1);
 		int numIndices = 2 * mSegmentsW * (mSegmentsH - 1) * 3;
 
@@ -162,7 +164,7 @@ public class Sphere extends Object3D {
 			}
 		}
 
-		setData(vertices, normals, textureCoords, colors, indices);
+		setData(vertices, normals, textureCoords, colors, indices, createVBOs);
 
 		vertices = null;
 		normals = null;

--- a/rajawali/src/main/java/rajawali/renderer/RajawaliRenderer.java
+++ b/rajawali/src/main/java/rajawali/renderer/RajawaliRenderer.java
@@ -12,6 +12,14 @@
  */
 package rajawali.renderer;
 
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.opengl.GLES20;
+import android.opengl.GLSurfaceView;
+import android.service.wallpaper.WallpaperService;
+import android.view.MotionEvent;
+import android.view.WindowManager;
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,14 +53,6 @@ import rajawali.util.RajLog;
 import rajawali.util.RawShaderLoader;
 import rajawali.visitors.INode;
 import rajawali.visitors.INodeVisitor;
-
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.opengl.GLES20;
-import android.opengl.GLSurfaceView;
-import android.service.wallpaper.WallpaperService;
-import android.view.MotionEvent;
-import android.view.WindowManager;
 
 public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 	protected final int GL_COVERAGE_BUFFER_BIT_NV = 0x8000;

--- a/rajawali/src/main/java/rajawali/renderer/plugins/IRendererPlugin.java
+++ b/rajawali/src/main/java/rajawali/renderer/plugins/IRendererPlugin.java
@@ -25,7 +25,8 @@ public interface IRendererPlugin {
 	
 	/**
 	 * Called by the RajawaliRenderer. You are responsible for settings up all
-	 * the necessary GL calls here to achieve your custom effect.
+	 * the necessary GL calls here to achieve your custom effect. You should always call
+     * through to the super method to ensure any geometry is handled properly.
 	 */
 	public void render();
 }

--- a/rajawali/src/main/java/rajawali/renderer/plugins/LensFlarePlugin.java
+++ b/rajawali/src/main/java/rajawali/renderer/plugins/LensFlarePlugin.java
@@ -12,6 +12,8 @@
  */
 package rajawali.renderer.plugins;
 
+import android.opengl.GLES20;
+
 import java.util.Stack;
 
 import rajawali.Camera;
@@ -22,7 +24,6 @@ import rajawali.math.Matrix4;
 import rajawali.math.vector.Vector2;
 import rajawali.math.vector.Vector3;
 import rajawali.renderer.RajawaliRenderer;
-import android.opengl.GLES20;
 
 
 /**
@@ -207,11 +208,15 @@ public final class LensFlarePlugin extends Plugin {
 	private ASingleTexture mOcclusionMapTexture;
 	
 	public LensFlarePlugin(RajawaliRenderer renderer) {
-		super(renderer);
+		this(renderer, true);
 	}
+
+    public LensFlarePlugin(RajawaliRenderer renderer, boolean createVBOs) {
+        super(renderer, createVBOs);
+    }
 	
 	@Override
-	protected void init() {
+	protected void init(boolean createVBOs) {
 		mLensFlares = new Stack<LensFlare>();
 		int[] maxVertexTextureImageUnits = new int[1]; 
 		GLES20.glGetIntegerv(GLES20.GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS, maxVertexTextureImageUnits, 0);
@@ -259,7 +264,7 @@ public final class LensFlarePlugin extends Plugin {
         }
         
         // Set geometry data.
-        setData(vertices, normals, textureCoords, colors, indices);
+        setData(vertices, normals, textureCoords, colors, indices, createVBOs);
         
         // TODO: deal with this
         /*
@@ -292,6 +297,7 @@ public final class LensFlarePlugin extends Plugin {
 	
 	@Override
 	public void render() {
+        super.render();
 		int f, i, numLensFlares = mLensFlares.size();
 		// Calculate world space position to normalized screen space.
 		double viewportWidth = mRenderer.getViewportWidth(), viewportHeight = mRenderer.getViewportHeight();

--- a/rajawali/src/main/java/rajawali/renderer/plugins/Plugin.java
+++ b/rajawali/src/main/java/rajawali/renderer/plugins/Plugin.java
@@ -12,11 +12,12 @@
  */
 package rajawali.renderer.plugins;
 
+import android.opengl.GLES20;
+
 import rajawali.Geometry3D;
 import rajawali.renderer.AFrameTask;
 import rajawali.renderer.RajawaliRenderer;
 import rajawali.util.RajLog;
-import android.opengl.GLES20;
 
 
 /**
@@ -37,13 +38,24 @@ public abstract class Plugin extends AFrameTask implements IRendererPlugin {
 	
 	/**
 	 * Instantiates a new renderer plugin.
+     *
 	 * @param renderer RajawaliRenderer instance which will be using this plugin.
 	 */
 	public Plugin(RajawaliRenderer renderer) {
-		mGeometry = new Geometry3D();
-		mRenderer = renderer;
-		init();
+		this(renderer, true);
 	}
+
+    /**
+     * Instantiates a new renderer plugin.
+     *
+     * @param renderer RajawaliRenderer instance which will be using this plugin.
+     * @param createVBOs {@code boolean} If true, any VBOs will be created immediately.
+     */
+    public Plugin(RajawaliRenderer renderer, boolean createVBOs) {
+        mGeometry = new Geometry3D();
+        mRenderer = renderer;
+        init(createVBOs);
+    }
 	
 	protected int createProgram(String vertexShader, String fragmentShader) {
 		mVShaderHandle = loadShader(GLES20.GL_VERTEX_SHADER, vertexShader);
@@ -93,7 +105,7 @@ public abstract class Plugin extends AFrameTask implements IRendererPlugin {
 	/**
 	 * Be sure to set up all the GL buffers and other initializations here.  
 	 */
-	protected void init() {}
+	protected void init(boolean createVBOs) {}
 	
 	protected int loadShader(int shaderType, String source) {
 		int shader = GLES20.glCreateShader(shaderType);
@@ -124,10 +136,12 @@ public abstract class Plugin extends AFrameTask implements IRendererPlugin {
 	/* (non-Javadoc)
 	 * @see rajawali.renderer.plugins.IRendererPlugin#render()
 	 */
-	public void render() {}
+	public void render() {
+        mGeometry.validateBuffers();
+    }
 	
-	protected void setData(float[] vertices, float[] normals, float[] textureCoords, float[] colors, int[] indices) {
-		mGeometry.setData(vertices, normals, textureCoords, colors, indices);
+	protected void setData(float[] vertices, float[] normals, float[] textureCoords, float[] colors, int[] indices, boolean createVBOs) {
+		mGeometry.setData(vertices, normals, textureCoords, colors, indices, createVBOs);
 	}
 	
 	protected void setShaders(String vertexShader, String fragmentShader) {

--- a/rajawali/src/main/java/rajawali/scene/RajawaliScene.java
+++ b/rajawali/src/main/java/rajawali/scene/RajawaliScene.java
@@ -12,6 +12,9 @@
  */
 package rajawali.scene;
 
+import android.graphics.Color;
+import android.opengl.GLES20;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -46,10 +49,10 @@ import rajawali.scenegraph.IGraphNode;
 import rajawali.scenegraph.IGraphNode.GRAPH_TYPE;
 import rajawali.scenegraph.IGraphNodeMember;
 import rajawali.scenegraph.Octree;
+import rajawali.util.GLU;
 import rajawali.util.ObjectColorPicker;
 import rajawali.util.ObjectColorPicker.ColorPickerInfo;
-import android.graphics.Color;
-import android.opengl.GLES20;
+import rajawali.util.RajLog;
 
 /**
  * This is the container class for scenes in Rajawali.
@@ -801,9 +804,9 @@ public class RajawaliScene extends AFrameTask {
 		if(sceneMat != null) {
 			sceneMat.useProgram();
 			sceneMat.bindTextures();
-		}		
+		}
 
-		synchronized (mChildren) {			
+        synchronized (mChildren) {
 			for (int i = 0, j = mChildren.size(); i < j; ++i) {
 				Object3D child = mChildren.get(i);
 				boolean blendingEnabled = child.isBlendingEnabled();

--- a/rajawali/src/main/java/rajawali/terrain/TerrainGenerator.java
+++ b/rajawali/src/main/java/rajawali/terrain/TerrainGenerator.java
@@ -36,9 +36,10 @@ public class TerrainGenerator {
 	 *            object that specify: ARGB Bitmap (R is temparature G is depth, A and B not used) Color Bitmpa
 	 *            (Optional) Number of divisions Scale of x,y,z coordinate TextureMult Specify the grid/texture relation
 	 *            Basecolor start color in relation with depth Middlecolor middle color Upcolor max depth color
+     * @param createVBOs
 	 * @return
 	 */
-	public static SquareTerrain createSquareTerrainFromBitmap(SquareTerrain.Parameters prs) {
+	public static SquareTerrain createSquareTerrainFromBitmap(SquareTerrain.Parameters prs, boolean createVBOs) {
 
 		int divisions = prs.divisions;
 
@@ -346,7 +347,7 @@ public class TerrainGenerator {
 
 		}
 
-		sq.setData(vertices, nors, textureCoords, colors, indices);
+		sq.setData(vertices, nors, textureCoords, colors, indices, createVBOs);
 		nors = null;
 		colors = null;
 		indices = null;


### PR DESCRIPTION
Allows objects to be constructed before an EGL context is available. This is useful if the `RajawaliFragment` is in a view pager, or if you need it in an app that will have multiple screens. This is the first step in allowing for completely creating a scene prior to `initScene()`, and thus asynchronously creating scenes.

Signed-off-by: Jared Woolston <jwoolston@tenkiv.com>