### PR TITLE
Adds an option to materials for deferred checking of device capabilities

### DIFF
--- a/rajawali/src/main/java/rajawali/Object3D.java
+++ b/rajawali/src/main/java/rajawali/Object3D.java
@@ -606,15 +606,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 	public void setForcedDepth(boolean forcedDepth) {
 		this.mForcedDepth = forcedDepth;
 	}
-/*
-	public ArrayList<TextureInfo> getTextureInfoList() {
-		ArrayList<TextureInfo> ti = mMaterial.getTextureInfoList();
 
-		for (int i = 0, j = mChildren.size(); i < j; i++)
-			ti.addAll(mChildren.get(i).getTextureInfoList());
-		return ti;
-	}
-*/
 	public SerializedObject3D toSerializedObject3D() {
 		SerializedObject3D ser = new SerializedObject3D(
 				mGeometry.getVertices() != null ? mGeometry.getVertices().capacity() : 0,

--- a/rajawali/src/main/java/rajawali/materials/Material.java
+++ b/rajawali/src/main/java/rajawali/materials/Material.java
@@ -75,6 +75,9 @@ public class Material extends AFrameTask {
 	{
 		PRE_LIGHTING, PRE_DIFFUSE, PRE_SPECULAR, PRE_ALPHA, PRE_TRANSFORM, POST_TRANSFORM, IGNORE
 	};
+
+    private final boolean mCapabilitiesCheckDeferred;
+
 	/**
 	 * The generic vertex shader. This can be extended by using vertex shader fragments.
 	 * A vertex shader is typically used to modify vertex positions, vertex colors and normals.
@@ -259,21 +262,35 @@ public class Material extends AFrameTask {
 	 * </code></pre>
 	 *
 	 */	
-	public Material()
-	{
-		mTextureList = new ArrayList<ATexture>();
-		mMaxTextures = Capabilities.getInstance().getMaxTextureImageUnits();
-		mColor = new float[] { 1, 0, 0, 1 };
-		mAmbientColor = new float[] {.2f, .2f, .2f};
-		mAmbientIntensity = new float[] {.3f, .3f, .3f};	
+	public Material() {
+		this(false);
 	}
+
+    public Material(boolean deferCapabilitiesCheck) {
+        mCapabilitiesCheckDeferred = deferCapabilitiesCheck;
+        mTextureList = new ArrayList<ATexture>();
+
+        // If we have deffered the capabilities check, we have no way of knowing how many textures this material
+        // is capable of having. We could choose 8, the minimum required fragment shader texture unit count, but
+        // that would not allow us to finish construction of this material until the EGL context is available. Instead,
+        // we are choosing the maximum integer Java can handle, and we will print a warning if the number of added textures
+        // exceeds the capability once known. In this event they will be used in listed order until the max is hit.
+        mMaxTextures = mCapabilitiesCheckDeferred ? Integer.MAX_VALUE : Capabilities.getInstance().getMaxTextureImageUnits();
+
+        mColor = new float[]{1, 0, 0, 1};
+        mAmbientColor = new float[]{.2f, .2f, .2f};
+        mAmbientIntensity = new float[]{.3f, .3f, .3f};
+    }
 	
-	public Material(VertexShader customVertexShader, FragmentShader customFragmentShader)
-	{
-		this();
-		mCustomVertexShader = customVertexShader;
-		mCustomFragmentShader = customFragmentShader;
+	public Material(VertexShader customVertexShader, FragmentShader customFragmentShader) {
+		this(customVertexShader, customFragmentShader, false);
 	}
+
+    public Material(VertexShader customVertexShader, FragmentShader customFragmentShader, boolean deferCapabilitiesCheck) {
+        this(deferCapabilitiesCheck);
+        mCustomVertexShader = customVertexShader;
+        mCustomFragmentShader = customFragmentShader;
+    }
 
     public void setDebug(boolean flag) {
         debug = flag;
@@ -437,7 +454,10 @@ public class Material extends AFrameTask {
 	 */
 	void add()
 	{
-		if(mLightingEnabled && mLights == null)
+        // We are being added to the scene, check the capabilities now if needed since they are available.
+		checkCapabilitiesIfNeeded();
+
+        if(mLightingEnabled && mLights == null)
 			return;
 
 		createShaders();
@@ -699,6 +719,14 @@ public class Material extends AFrameTask {
 
 		mIsDirty = false;
 	}
+
+    /**
+     * Checks if the device capabilities need to be checked to update the count of available texture units.
+     */
+    private void checkCapabilitiesIfNeeded() {
+        if (!mCapabilitiesCheckDeferred) return;
+        mMaxTextures = Capabilities.getInstance().getMaxTextureImageUnits();
+    }
 	
 	/**
 	 * Checks if any {@link IMaterialPlugin}s have been added. If so they will be added
@@ -829,7 +857,11 @@ public class Material extends AFrameTask {
 	 * be called manually.
 	 */
 	public void bindTextures() {
-		int num = mTextureList.size();
+		// Assume its the number of textures
+        int num = mTextureList.size();
+        // Check if the number of applied textures is larger than the max texture count
+        // - this would be due to deferred capabilities checking. If so, choose max texture count.
+        if (num > mMaxTextures) num = mMaxTextures;
 
 		for (int i = 0; i < num; i++) {
 			ATexture texture = mTextureList.get(i);

--- a/rajawali/src/main/java/rajawali/renderer/RajawaliRenderer.java
+++ b/rajawali/src/main/java/rajawali/renderer/RajawaliRenderer.java
@@ -140,10 +140,16 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
 
     private long mRenderStartTime;
 
-	public RajawaliRenderer(Context context) {
+    private final boolean mHaveRegisteredForResources;
+
+    public RajawaliRenderer(Context context) {
+        this(context, false);
+    }
+
+	public RajawaliRenderer(Context context, boolean registerForResources) {
 		RajLog.i("Rajawali | Anchor Steam | Dev Branch");
 		RajLog.i("THIS IS A DEV BRANCH CONTAINING SIGNIFICANT CHANGES. PLEASE REFER TO CHANGELOG.md FOR MORE INFORMATION.");
-		
+		mHaveRegisteredForResources = registerForResources;
 		mContext = context;
 		mFrameRate = getRefreshRate();
 		mScenes = Collections.synchronizedList(new CopyOnWriteArrayList<RajawaliScene>());
@@ -161,6 +167,20 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
         mCurrentScene = defaultScene;
 
 		RawShaderLoader.mContext = new WeakReference<Context>(context);
+
+        // Make sure we have a texture manager
+        mTextureManager = TextureManager.getInstance();
+        mTextureManager.setContext(getContext());
+
+        // Make sure we have a material manager
+        mMaterialManager = MaterialManager.getInstance();
+        mMaterialManager.setContext(getContext());
+
+        // We are registering now
+        if (registerForResources) {
+            mTextureManager.registerRenderer(this);
+            mMaterialManager.registerRenderer(this);
+        }
 	}
 	
 	/**
@@ -581,13 +601,11 @@ public class RajawaliRenderer implements GLSurfaceView.Renderer, INode {
         RajLog.d(String.format(Locale.US, "Derived GL ES Version: %d.%d", mGLES_Major_Version, mGLES_Minor_Version));
 		
 		supportsUIntBuffers = gl.glGetString(GL10.GL_EXTENSIONS).contains("GL_OES_element_index_uint");
-		
-		mTextureManager = TextureManager.getInstance();
-		mTextureManager.setContext(this.getContext());
-		mTextureManager.registerRenderer(this);
-		mMaterialManager = MaterialManager.getInstance();
-		mMaterialManager.setContext(this.getContext());
-		mMaterialManager.registerRenderer(this);
+
+        if (!mHaveRegisteredForResources) {
+            mTextureManager.registerRenderer(this);
+            mMaterialManager.registerRenderer(this);
+        }
 	}
 	
 	/**


### PR DESCRIPTION
Adds an option to materials for deferred checking of device capabilities (used for determining maximum texture count). If it is deferred and you add too many textures, an error message will be printed but the maximum possible number of textures will be used, going in list order. Along with this, an option has been added to allow a RajawaliRenderer implementation to register with the resource managers in its constructor rather than waiting until onSurfaceCreated(). If you register in the constructor, registration will not occur in the onSurfaceCreated callback.

Signed-off-by: Jared Woolston <jwoolston@tenkiv.com>