### PR TITLE
Adds ETC2 texture support

### DIFF
--- a/rajawali/src/main/java/rajawali/Capabilities.java
+++ b/rajawali/src/main/java/rajawali/Capabilities.java
@@ -1,266 +1,337 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package rajawali;
 
+import android.opengl.EGLExt;
 import android.opengl.GLES20;
+import android.os.Build;
+
+import javax.microedition.khronos.egl.EGL10;
+import javax.microedition.khronos.egl.EGLConfig;
+import javax.microedition.khronos.egl.EGLContext;
+import javax.microedition.khronos.egl.EGLDisplay;
+
+import rajawali.util.RajLog;
 
 
 /**
  * Lists all OpenGL specific capabilities
- * 
- * @author dennis.ippel
  *
+ * @author dennis.ippel
  */
 public class Capabilities {
-	private static Capabilities instance = null;
-	
-	private int mMaxTextureSize;
-	private int mMaxCombinedTextureImageUnits;
-	private int mMaxCubeMapTextureSize;
-	private int mMaxFragmentUniformVectors;
-	private int mMaxRenderbufferSize;
-	private int mMaxTextureImageUnits;
-	private int mMaxVaryingVectors;
-	private int mMaxVertexAttribs;
-	private int mMaxVertexTextureImageUnits;
-	private int mMaxVertexUniformVectors;
-	private int mMaxViewportWidth;
-	private int mMaxViewportHeight;
-	private int mMinAliasedLineWidth;
-	private int mMaxAliasedLineWidth;
-	private int mMinAliasedPointSize;
-	private int mMaxAliasedPointSize; 
-	
-	private int[] mParam;
-	
-	private Capabilities()
-	{
-		initialize();
-	}
-	
-	public static Capabilities getInstance()
-	{
-		if(instance == null)
-		{
-			instance = new Capabilities();
-		}
-		return instance;
-	}
-	
-	public void initialize()
-	{
-		mParam = new int[1];
-		
-		mMaxCombinedTextureImageUnits = getInt(GLES20.GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS);
-		mMaxCubeMapTextureSize = getInt(GLES20.GL_MAX_CUBE_MAP_TEXTURE_SIZE);
-		mMaxFragmentUniformVectors = getInt(GLES20.GL_MAX_FRAGMENT_UNIFORM_VECTORS);
-		mMaxRenderbufferSize = getInt(GLES20.GL_MAX_RENDERBUFFER_SIZE);
-		mMaxTextureImageUnits = getInt(GLES20.GL_MAX_TEXTURE_IMAGE_UNITS);
-		mMaxTextureSize = getInt(GLES20.GL_MAX_TEXTURE_SIZE);
-		mMaxVaryingVectors = getInt(GLES20.GL_MAX_VARYING_VECTORS);
-		mMaxVertexAttribs = getInt(GLES20.GL_MAX_VERTEX_ATTRIBS);
-		mMaxVertexTextureImageUnits = getInt(GLES20.GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS);
-		mMaxVertexUniformVectors = getInt(GLES20.GL_MAX_VERTEX_UNIFORM_VECTORS);
-		mMaxViewportWidth = getInt(GLES20.GL_MAX_VIEWPORT_DIMS, 2, 0);
-		mMaxViewportHeight = getInt(GLES20.GL_MAX_VIEWPORT_DIMS, 2, 1);
-		mMinAliasedLineWidth = getInt(GLES20.GL_ALIASED_LINE_WIDTH_RANGE, 2, 0);
-		mMaxAliasedLineWidth = getInt(GLES20.GL_ALIASED_LINE_WIDTH_RANGE, 2, 1);
-		mMinAliasedPointSize = getInt(GLES20.GL_ALIASED_POINT_SIZE_RANGE, 2, 0);
-		mMaxAliasedPointSize = getInt(GLES20.GL_ALIASED_POINT_SIZE_RANGE, 2, 1);
-	}
-	
-	private int getInt(int pname)
-	{
-		GLES20.glGetIntegerv(pname, mParam, 0);
-		return mParam[0];
-	}
-	
-	private int getInt(int pname, int length, int index)
-	{
-		int[] params = new int[length];
-		GLES20.glGetIntegerv(pname, params, 0);
-		return params[index];
-	}
-	
-	/**
-	 * A rough estimate of the largest texture that OpenGL can handle.
-	 * @return
-	 */
-	public int getMaxTextureSize()
-	{
-		return mMaxTextureSize;
-	}
-	
-	/**
-	 * The maximum supported texture image units that can be used to access texture maps from the vertex shader 
-	 * and the fragment processor combined. If both the vertex shader and the fragment processing stage access 
-	 * the same texture image unit, then that counts as using two texture image units against this limit.
-	 * @return
-	 */
-	public int getMaxCombinedTextureUnits()
-	{
-		return mMaxCombinedTextureImageUnits;
-	}
-	
-	/**
-	 * The value gives a rough estimate of the largest cube-map texture that the GL can handle. 
-	 * The value must be at least 1024. 
-	 * @return
-	 */
-	public int getMaxCubeMapTextureSize()
-	{
-		return mMaxCubeMapTextureSize;
-	}
-	
-	/**
-	 * The maximum number of individual 4-vectors of floating-point, integer, or boolean values that can be held 
-	 * in uniform variable storage for a fragment shader. 
-	 * @return
-	 */
-	public int getMaxFragmentUniformVectors()
-	{
-		return mMaxFragmentUniformVectors;
-	}
-	
-	/**
-	 * Indicates the maximum supported size for renderbuffers. 
-	 * @return
-	 */
-	public int getMaxRenderbufferSize()
-	{
-		return mMaxRenderbufferSize;
-	}
-	
-	/**
-	 * The maximum supported texture image units that can be used to access texture maps from the fragment shader. 
-	 * @return
-	 */
-	public int getMaxTextureImageUnits()
-	{
-		return mMaxTextureImageUnits;
-	}
-	
-	/**
-	 * The maximum number of 4-vectors for varying variables.
-	 * @return
-	 */
-	public int getMaxVaryingVectors()
-	{
-		return mMaxVaryingVectors;
-	}
-	
-	/**
-	 * The maximum number of 4-component generic vertex attributes accessible to a vertex shader.
-	 * @return
-	 */
-	public int getMaxVertexAttribs()
-	{
-		return mMaxVertexAttribs;
-	}
-	
-	/**
-	 * The maximum supported texture image units that can be used to access texture maps from the vertex shader.
-	 * @return
-	 */
-	public int getMaxVertexTextureImageUnits()
-	{
-		return mMaxVertexTextureImageUnits;
-	}
-	
-	/**
-	 * The maximum number of 4-vectors that may be held in uniform variable storage for the vertex shader.
-	 * @return
-	 */
-	public int getMaxVertexUniformVectors()
-	{
-		return mMaxVertexUniformVectors;
-	}
-	
-	/**
-	 * The maximum supported viewport width
-	 * @return
-	 */
-	public int getMaxViewportWidth()
-	{
-		return mMaxViewportWidth;
-	}
-	
-	/**
-	 * The maximum supported viewport height
-	 * @return
-	 */
-	public int getMaxViewportHeight()
-	{
-		return mMaxViewportHeight;
-	}
-	
-	/**
-	 * Indicates the minimum width supported for aliased lines
-	 * @return
-	 */
-	public int getMinAliasedLineWidth()
-	{
-		return mMinAliasedLineWidth;
-	}
-	
-	/**
-	 * Indicates the maximum width supported for aliased lines
-	 * @return
-	 */
-	public int getMaxAliasedLineWidth()
-	{
-		return mMaxAliasedLineWidth;
-	}
-	
-	/**
-	 * Indicates the minimum size supported for aliased points
-	 * @return
-	 */
-	public int getMinAliasedPointSize()
-	{
-		return mMinAliasedPointSize;
-	}
-	
-	/**
-	 * Indicates the maximum size supported for aliased points
-	 * @return
-	 */
-	public int getMaxAliasedPointSize()
-	{
-		return mMaxAliasedPointSize;
-	}
-	
-	public String toString()
-	{
-		StringBuffer sb = new StringBuffer();
-		sb.append("-=-=-=- OpenGL Capabilities -=-=-=-\n");
-		sb.append("Max Combined Texture Image Units   : ").append(mMaxCombinedTextureImageUnits).append("\n");
-		sb.append("Max Cube Map Texture Size          : ").append(mMaxCubeMapTextureSize).append("\n");
-		sb.append("Max Fragment Uniform Vectors       : ").append(mMaxFragmentUniformVectors).append("\n");
-		sb.append("Max Renderbuffer Size              : ").append(mMaxRenderbufferSize).append("\n");
-		sb.append("Max Texture Image Units            : ").append(mMaxTextureImageUnits).append("\n");
-		sb.append("Max Texture Size                   : ").append(mMaxTextureSize).append("\n");
-		sb.append("Max Varying Vectors                : ").append(mMaxVaryingVectors).append("\n");
-		sb.append("Max Vertex Attribs                 : ").append(mMaxVertexAttribs).append("\n");
-		sb.append("Max Vertex Texture Image Units     : ").append(mMaxVertexTextureImageUnits).append("\n");
-		sb.append("Max Vertex Uniform Vectors         : ").append(mMaxVertexUniformVectors).append("\n");
-		sb.append("Max Viewport Width                 : ").append(mMaxViewportWidth).append("\n");
-		sb.append("Max Viewport Height                : ").append(mMaxViewportHeight).append("\n");
-		sb.append("Min Aliased Line Width             : ").append(mMinAliasedLineWidth).append("\n");
-		sb.append("Max Aliased Line Width             : ").append(mMaxAliasedLineWidth).append("\n");
-		sb.append("Min Aliased Point Size             : ").append(mMinAliasedPointSize).append("\n");
-		sb.append("Max Aliased Point Width            : ").append(mMaxAliasedPointSize).append("\n");
-		sb.append("-=-=-=- /OpenGL Capabilities -=-=-=-\n");
-		return sb.toString();
-	}
+    private static Capabilities instance = null;
+
+    private static volatile boolean sGLChecked = false;
+
+    private static int mEGLMajorVersion;
+    private static int mEGLMinorVersion;
+    private static int mGLESMajorVersion;
+
+    private int mMaxTextureSize;
+    private int mMaxCombinedTextureImageUnits;
+    private int mMaxCubeMapTextureSize;
+    private int mMaxFragmentUniformVectors;
+    private int mMaxRenderbufferSize;
+    private int mMaxTextureImageUnits;
+    private int mMaxVaryingVectors;
+    private int mMaxVertexAttribs;
+    private int mMaxVertexTextureImageUnits;
+    private int mMaxVertexUniformVectors;
+    private int mMaxViewportWidth;
+    private int mMaxViewportHeight;
+    private int mMinAliasedLineWidth;
+    private int mMaxAliasedLineWidth;
+    private int mMinAliasedPointSize;
+    private int mMaxAliasedPointSize;
+
+    private int[] mParam;
+
+    private Capabilities() {
+        initialize();
+    }
+
+    public static Capabilities getInstance() {
+        if (instance == null) {
+            instance = new Capabilities();
+        }
+        return instance;
+    }
+
+    private static void checkGLVersion() {
+        // Get an EGL context and display
+        final EGL10 egl = (EGL10) EGLContext.getEGL();
+        final EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
+
+        final int[] version = new int[2];
+        if (!egl.eglInitialize(display, version)) throw new IllegalStateException("Failed to initialize and EGL context while getting device capabilities.");
+        mEGLMajorVersion = version[0];
+        mEGLMinorVersion = version[1];
+        // RajLog.d("Device EGL Version: " + version[0] + "." + version[1]);
+
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
+            // The API for GLES3 doesnt exist on this device
+            // RajLog.d("Device is API level cannot support OpenGL ES 3.");
+            mGLESMajorVersion = 2;
+        } else {
+            // The API for GLES3 might exist, we need to check
+            // RajLog.d("Attempting to get an OpenGL ES 3 config.");
+            final int[] configAttribs = {EGL10.EGL_RED_SIZE, 4, EGL10.EGL_GREEN_SIZE, 4, EGL10.EGL_BLUE_SIZE, 4,
+                EGL10.EGL_RENDERABLE_TYPE, EGLExt.EGL_OPENGL_ES3_BIT_KHR, EGL10.EGL_NONE};
+
+            final EGLConfig[] configs = new EGLConfig[10];
+            final int[] num_config = new int[1];
+            egl.eglChooseConfig(display, configAttribs, configs, 10, num_config);
+            egl.eglTerminate(display);
+            mGLESMajorVersion = num_config[0] > 0 ? 3 : 2;
+        }
+
+        // RajLog.d("Determined GLES Major version to be: " + mGLESMajorVersion);
+        sGLChecked = true;
+    }
+
+    private void initialize() {
+        RajLog.d(this, "Fetching device capabilities.");
+
+        mParam = new int[1];
+
+        mMaxCombinedTextureImageUnits = getInt(GLES20.GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS);
+        mMaxCubeMapTextureSize = getInt(GLES20.GL_MAX_CUBE_MAP_TEXTURE_SIZE);
+        mMaxFragmentUniformVectors = getInt(GLES20.GL_MAX_FRAGMENT_UNIFORM_VECTORS);
+        mMaxRenderbufferSize = getInt(GLES20.GL_MAX_RENDERBUFFER_SIZE);
+        mMaxTextureImageUnits = getInt(GLES20.GL_MAX_TEXTURE_IMAGE_UNITS);
+        mMaxTextureSize = getInt(GLES20.GL_MAX_TEXTURE_SIZE);
+        mMaxVaryingVectors = getInt(GLES20.GL_MAX_VARYING_VECTORS);
+        mMaxVertexAttribs = getInt(GLES20.GL_MAX_VERTEX_ATTRIBS);
+        mMaxVertexTextureImageUnits = getInt(GLES20.GL_MAX_VERTEX_TEXTURE_IMAGE_UNITS);
+        mMaxVertexUniformVectors = getInt(GLES20.GL_MAX_VERTEX_UNIFORM_VECTORS);
+        mMaxViewportWidth = getInt(GLES20.GL_MAX_VIEWPORT_DIMS, 2, 0);
+        mMaxViewportHeight = getInt(GLES20.GL_MAX_VIEWPORT_DIMS, 2, 1);
+        mMinAliasedLineWidth = getInt(GLES20.GL_ALIASED_LINE_WIDTH_RANGE, 2, 0);
+        mMaxAliasedLineWidth = getInt(GLES20.GL_ALIASED_LINE_WIDTH_RANGE, 2, 1);
+        mMinAliasedPointSize = getInt(GLES20.GL_ALIASED_POINT_SIZE_RANGE, 2, 0);
+        mMaxAliasedPointSize = getInt(GLES20.GL_ALIASED_POINT_SIZE_RANGE, 2, 1);
+    }
+
+    private int getInt(int pname) {
+        GLES20.glGetIntegerv(pname, mParam, 0);
+        return mParam[0];
+    }
+
+    private int getInt(int pname, int length, int index) {
+        int[] params = new int[length];
+        GLES20.glGetIntegerv(pname, params, 0);
+        return params[index];
+    }
+
+    /**
+     * The EGL major version number of this device.
+     *
+     * @return
+     */
+    public static int getEGLMajorVersion() {
+        if (!sGLChecked) checkGLVersion();
+        return mEGLMajorVersion;
+    }
+
+    /**
+     * The EGL minor version number of this device.
+     *
+     * @return
+     */
+    public static int getEGLMinorVersion() {
+        if (!sGLChecked) checkGLVersion();
+        return mEGLMinorVersion;
+    }
+
+    /**
+     * The highest GL ES major version number supported by this device.
+     *
+     * @return
+     */
+    public static int getGLESMajorVersion() {
+        if (!sGLChecked) checkGLVersion();
+        return mGLESMajorVersion;
+    }
+
+    /**
+     * A rough estimate of the largest texture that OpenGL can handle.
+     *
+     * @return
+     */
+    public int getMaxTextureSize() {
+        return mMaxTextureSize;
+    }
+
+    /**
+     * The maximum supported texture image units that can be used to access texture maps from the vertex shader
+     * and the fragment processor combined. If both the vertex shader and the fragment processing stage access
+     * the same texture image unit, then that counts as using two texture image units against this limit.
+     *
+     * @return
+     */
+    public int getMaxCombinedTextureUnits() {
+        return mMaxCombinedTextureImageUnits;
+    }
+
+    /**
+     * The value gives a rough estimate of the largest cube-map texture that the GL can handle.
+     * The value must be at least 1024.
+     *
+     * @return
+     */
+    public int getMaxCubeMapTextureSize() {
+        return mMaxCubeMapTextureSize;
+    }
+
+    /**
+     * The maximum number of individual 4-vectors of floating-point, integer, or boolean values that can be held
+     * in uniform variable storage for a fragment shader.
+     *
+     * @return
+     */
+    public int getMaxFragmentUniformVectors() {
+        return mMaxFragmentUniformVectors;
+    }
+
+    /**
+     * Indicates the maximum supported size for renderbuffers.
+     *
+     * @return
+     */
+    public int getMaxRenderbufferSize() {
+        return mMaxRenderbufferSize;
+    }
+
+    /**
+     * The maximum supported texture image units that can be used to access texture maps from the fragment shader.
+     *
+     * @return
+     */
+    public int getMaxTextureImageUnits() {
+        return mMaxTextureImageUnits;
+    }
+
+    /**
+     * The maximum number of 4-vectors for varying variables.
+     *
+     * @return
+     */
+    public int getMaxVaryingVectors() {
+        return mMaxVaryingVectors;
+    }
+
+    /**
+     * The maximum number of 4-component generic vertex attributes accessible to a vertex shader.
+     *
+     * @return
+     */
+    public int getMaxVertexAttribs() {
+        return mMaxVertexAttribs;
+    }
+
+    /**
+     * The maximum supported texture image units that can be used to access texture maps from the vertex shader.
+     *
+     * @return
+     */
+    public int getMaxVertexTextureImageUnits() {
+        return mMaxVertexTextureImageUnits;
+    }
+
+    /**
+     * The maximum number of 4-vectors that may be held in uniform variable storage for the vertex shader.
+     *
+     * @return
+     */
+    public int getMaxVertexUniformVectors() {
+        return mMaxVertexUniformVectors;
+    }
+
+    /**
+     * The maximum supported viewport width
+     *
+     * @return
+     */
+    public int getMaxViewportWidth() {
+        return mMaxViewportWidth;
+    }
+
+    /**
+     * The maximum supported viewport height
+     *
+     * @return
+     */
+    public int getMaxViewportHeight() {
+        return mMaxViewportHeight;
+    }
+
+    /**
+     * Indicates the minimum width supported for aliased lines
+     *
+     * @return
+     */
+    public int getMinAliasedLineWidth() {
+        return mMinAliasedLineWidth;
+    }
+
+    /**
+     * Indicates the maximum width supported for aliased lines
+     *
+     * @return
+     */
+    public int getMaxAliasedLineWidth() {
+        return mMaxAliasedLineWidth;
+    }
+
+    /**
+     * Indicates the minimum size supported for aliased points
+     *
+     * @return
+     */
+    public int getMinAliasedPointSize() {
+        return mMinAliasedPointSize;
+    }
+
+    /**
+     * Indicates the maximum size supported for aliased points
+     *
+     * @return
+     */
+    public int getMaxAliasedPointSize() {
+        return mMaxAliasedPointSize;
+    }
+
+    public String toString() {
+        StringBuffer sb = new StringBuffer();
+        sb.append("-=-=-=- OpenGL Capabilities -=-=-=-\n");
+        sb.append("Max Combined Texture Image Units   : ").append(mMaxCombinedTextureImageUnits).append("\n");
+        sb.append("Max Cube Map Texture Size          : ").append(mMaxCubeMapTextureSize).append("\n");
+        sb.append("Max Fragment Uniform Vectors       : ").append(mMaxFragmentUniformVectors).append("\n");
+        sb.append("Max Renderbuffer Size              : ").append(mMaxRenderbufferSize).append("\n");
+        sb.append("Max Texture Image Units            : ").append(mMaxTextureImageUnits).append("\n");
+        sb.append("Max Texture Size                   : ").append(mMaxTextureSize).append("\n");
+        sb.append("Max Varying Vectors                : ").append(mMaxVaryingVectors).append("\n");
+        sb.append("Max Vertex Attribs                 : ").append(mMaxVertexAttribs).append("\n");
+        sb.append("Max Vertex Texture Image Units     : ").append(mMaxVertexTextureImageUnits).append("\n");
+        sb.append("Max Vertex Uniform Vectors         : ").append(mMaxVertexUniformVectors).append("\n");
+        sb.append("Max Viewport Width                 : ").append(mMaxViewportWidth).append("\n");
+        sb.append("Max Viewport Height                : ").append(mMaxViewportHeight).append("\n");
+        sb.append("Min Aliased Line Width             : ").append(mMinAliasedLineWidth).append("\n");
+        sb.append("Max Aliased Line Width             : ").append(mMaxAliasedLineWidth).append("\n");
+        sb.append("Min Aliased Point Size             : ").append(mMinAliasedPointSize).append("\n");
+        sb.append("Max Aliased Point Width            : ").append(mMaxAliasedPointSize).append("\n");
+        sb.append("-=-=-=- /OpenGL Capabilities -=-=-=-\n");
+        return sb.toString();
+    }
 }

--- a/rajawali/src/main/java/rajawali/RajawaliActivity.java
+++ b/rajawali/src/main/java/rajawali/RajawaliActivity.java
@@ -30,10 +30,7 @@ import rajawali.util.egl.RajawaliEGLConfigChooser;
 /**
  * This is a standard Android SDK based activity which manages 
  * the Rajawali engine. In general, you may want to consider
- * using {@link RajawaliFragment} over this class, however if you are
- * developing for compatibility with API 8-10 (2.2-2.3.3), and want
- * to use fragments in your app, you will need to use 
- * {@link RajawaliFragmentActivity} instead.
+ * using {@link RajawaliFragment} over this class.
  */
 public class RajawaliActivity extends Activity {
 	protected GLSurfaceView mSurfaceView;
@@ -60,7 +57,7 @@ public class RajawaliActivity extends Activity {
         	if(info.reqGlEsVersion < 0x20000)
         		throw new Error("OpenGL ES 2.0 is not supported by this device");
         }
-        mSurfaceView.setEGLContextClientVersion(2);
+        mSurfaceView.setEGLContextClientVersion(Capabilities.getGLESMajorVersion());
         
         mLayout = new FrameLayout(this);
         mLayout.addView(mSurfaceView);

--- a/rajawali/src/main/java/rajawali/RajawaliDaydream.java
+++ b/rajawali/src/main/java/rajawali/RajawaliDaydream.java
@@ -39,7 +39,7 @@ public abstract class RajawaliDaydream extends DreamService implements IRajawali
 		super.onAttachedToWindow();
 
 		mSurfaceView = new GLSurfaceView(this);
-		mSurfaceView.setEGLContextClientVersion(2);
+		mSurfaceView.setEGLContextClientVersion(Capabilities.getGLESMajorVersion());
 
 		setInteractive(false);
 		setFullscreen(true);

--- a/rajawali/src/main/java/rajawali/RajawaliFragment.java
+++ b/rajawali/src/main/java/rajawali/RajawaliFragment.java
@@ -74,7 +74,7 @@ public abstract class RajawaliFragment extends Fragment implements IRajawaliDisp
         }
 
         mSurfaceView = new GLSurfaceView(getActivity());
-        mSurfaceView.setEGLContextClientVersion(2);
+        mSurfaceView.setEGLContextClientVersion(Capabilities.getGLESMajorVersion());
 
         mRenderer = createRenderer();
         if (mRenderer == null)

--- a/rajawali/src/main/java/rajawali/RajawaliSupportFragment.java
+++ b/rajawali/src/main/java/rajawali/RajawaliSupportFragment.java
@@ -31,7 +31,7 @@ import rajawali.util.egl.RajawaliEGLConfigChooser;
  * provide it as a {@link android.widget.FrameLayout} and be sure to call {@link super#onCreateView(LayoutInflater, ViewGroup, Bundle)}
  * once you have set {@link #mLayout}.
  *
- * @author Jared Woolston (jwoolston@idealcorp.com)
+ * @author Jared Woolston (jwoolston@tenkiv.com)
  */
 public abstract class RajawaliSupportFragment extends Fragment implements IRajawaliDisplay {
 

--- a/rajawali/src/main/java/rajawali/RajawaliSupportFragment.java
+++ b/rajawali/src/main/java/rajawali/RajawaliSupportFragment.java
@@ -64,7 +64,7 @@ public abstract class RajawaliSupportFragment extends Fragment implements IRajaw
         }
 
         mSurfaceView = new GLSurfaceView(getActivity());
-        mSurfaceView.setEGLContextClientVersion(2);
+        mSurfaceView.setEGLContextClientVersion(Capabilities.getGLESMajorVersion());
 
         mRenderer = createRenderer();
         mRenderer.setSurfaceView(mSurfaceView);

--- a/rajawali/src/main/java/rajawali/materials/textures/ACompressedTexture.java
+++ b/rajawali/src/main/java/rajawali/materials/textures/ACompressedTexture.java
@@ -27,6 +27,7 @@ public abstract class ACompressedTexture extends ATexture {
 	public enum CompressionType {
 		NONE,
 		ETC1,
+        ETC2,
 		PALETTED,
 		THREEDC,
 		ATC,

--- a/rajawali/src/main/java/rajawali/materials/textures/Etc2Texture.java
+++ b/rajawali/src/main/java/rajawali/materials/textures/Etc2Texture.java
@@ -1,0 +1,198 @@
+package rajawali.materials.textures;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.opengl.ETC1;
+import android.opengl.GLES11Ext;
+import android.opengl.GLES30;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import rajawali.materials.textures.utils.ETC2Util;
+import rajawali.util.RajLog;
+
+/**
+ * Rajawali container for an ETC2 texture. Due to the nature of ETC2 textures, you may also use this to load
+ * an ETC1 texture.
+ *
+ * The following GL internal formats are supported:
+ * - {@link GLES11Ext#GL_ETC1_RGB8_OES}
+ * - {@link GLES30#GL_COMPRESSED_RGB8_ETC2}
+ * - {@link GLES30#GL_COMPRESSED_RGBA8_ETC2_EAC}
+ * - {@link GLES30#GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2}
+ * - {@link GLES30#GL_COMPRESSED_R11_EAC}
+ * - {@link GLES30#GL_COMPRESSED_RG11_EAC}
+ * - {@link GLES30#GL_COMPRESSED_SIGNED_R11_EAC}
+ * - {@link GLES30#GL_COMPRESSED_SIGNED_RG11_EAC}
+ *
+ * In theory, the sRGB types {@link GLES30#GL_COMPRESSED_SRGB8_ETC2}, {@link GLES30#GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC},
+ * and {@link GLES30#GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2} are also supported, but they will currently fail the
+ * header check because no source was available to determine their internal type codes.
+ *
+ * //TODO: Find internal type codes for sRGB formats.
+ *
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public class Etc2Texture extends ACompressedTexture {
+
+    protected int mResourceId;
+    protected Bitmap mBitmap;
+
+    public Etc2Texture(String textureName) {
+        super(textureName);
+        mCompressionType = CompressionType.ETC2;
+    }
+
+    public Etc2Texture(int resourceId) {
+        this(TextureManager.getInstance().getContext().getResources().getResourceName(resourceId));
+        setResourceId(resourceId);
+    }
+
+    public Etc2Texture(String textureName, int resourceId, Bitmap fallbackTexture) {
+        this(textureName);
+        Context context = TextureManager.getInstance().getContext();
+        setInputStream(context.getResources().openRawResource(resourceId), fallbackTexture);
+    }
+
+    public Etc2Texture(String textureName, int[] resourceIds) {
+        this(textureName);
+        setResourceIds(resourceIds);
+    }
+
+    public Etc2Texture(String textureName, ByteBuffer byteBuffer) {
+        this(textureName);
+        setByteBuffer(byteBuffer);
+    }
+
+    public Etc2Texture(String textureName, ByteBuffer[] byteBuffers) {
+        this(textureName);
+        setByteBuffers(byteBuffers);
+    }
+
+    public Etc2Texture(String textureName, InputStream compressedTexture, Bitmap fallbackTexture) {
+        this(textureName);
+        setInputStream(compressedTexture, fallbackTexture);
+    }
+
+    public Etc2Texture(Etc1Texture other) {
+        super();
+        setFrom(other);
+    }
+
+    @Override
+    public ATexture clone() {
+        return null;
+    }
+
+    @Override
+    void add() throws TextureException {
+        super.add();
+        if (mShouldRecycle) {
+            if (mBitmap != null) {
+                mBitmap.recycle();
+                mBitmap = null;
+            }
+        }
+    }
+
+    @Override
+    void reset() throws TextureException {
+        super.reset();
+        if (mBitmap != null) {
+            mBitmap.recycle();
+            mBitmap = null;
+        }
+    }
+
+    public void setResourceId(int resourceId) {
+        mResourceId = resourceId;
+        Resources resources = TextureManager.getInstance().getContext().getResources();
+        try {
+            ETC2Util.ETC2Texture texture = ETC2Util.createTexture(resources.openRawResource(resourceId));
+            mByteBuffers = new ByteBuffer[]{texture.getData()};
+            setWidth(texture.getWidth());
+            setHeight(texture.getHeight());
+            setCompressionFormat(texture.getCompressionFormat());
+        } catch (IOException e) {
+            RajLog.e(e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    public int getResourceId() {
+        return mResourceId;
+    }
+
+    public void setResourceIds(int[] resourceIds) {
+        ByteBuffer[] mipmapChain = new ByteBuffer[resourceIds.length];
+        Resources resources = TextureManager.getInstance().getContext().getResources();
+        int mip_0_width = 1, mip_0_height = 1;
+        try {
+            for (int i = 0, length = resourceIds.length; i < length; i++) {
+                ETC2Util.ETC2Texture texture = ETC2Util.createTexture(resources.openRawResource(resourceIds[i]));
+                if (i == 0) {
+                    setCompressionFormat(texture.getCompressionFormat());
+                } else {
+                    if (getCompressionFormat() != texture.getCompressionFormat()) {
+                        throw new IllegalArgumentException("The ETC2 compression formats of all textures in the chain much match");
+                    }
+                }
+                mipmapChain[i] = texture.getData();
+                if (i == 0) {
+                    mip_0_width = texture.getWidth();
+                    mip_0_height = texture.getHeight();
+                }
+            }
+            setWidth(mip_0_width);
+            setHeight(mip_0_height);
+        } catch (IOException e) {
+            RajLog.e(e.getMessage());
+            e.printStackTrace();
+        }
+
+        mByteBuffers = mipmapChain;
+    }
+
+    public void setInputStream(InputStream compressedTexture, Bitmap fallbackTexture) {
+        ETC2Util.ETC2Texture texture = null;
+
+        try {
+            texture = ETC2Util.createTexture(compressedTexture);
+        } catch (IOException e) {
+            RajLog.e("addEtc2Texture", e.getMessage());
+        } finally {
+            if (texture == null) {
+                setBitmap(fallbackTexture);
+                RajLog.d("ETC2", "Falling back to ETC1 texture from fallback texture.");
+            } else {
+                setCompressionFormat(texture.getCompressionFormat());
+                setByteBuffer(texture.getData());
+                setWidth(texture.getWidth());
+                setHeight(texture.getHeight());
+                RajLog.d("ETC2", "ETC2 texture load successful");
+            }
+        }
+    }
+
+    private void setBitmap(Bitmap bitmap) {
+        mBitmap = bitmap;
+        int imageSize = bitmap.getRowBytes() * bitmap.getHeight();
+        ByteBuffer uncompressedBuffer = ByteBuffer.allocateDirect(imageSize);
+        bitmap.copyPixelsToBuffer(uncompressedBuffer);
+        uncompressedBuffer.position(0);
+
+        ByteBuffer compressedBuffer = ByteBuffer.allocateDirect(
+            ETC1.getEncodedDataSize(bitmap.getWidth(), bitmap.getHeight())).order(ByteOrder.nativeOrder());
+        ETC1.encodeImage(uncompressedBuffer, bitmap.getWidth(), bitmap.getHeight(), 2, 2 * bitmap.getWidth(),
+            compressedBuffer);
+        setCompressionFormat(ETC1.ETC1_RGB8_OES);
+
+        mByteBuffers = new ByteBuffer[]{compressedBuffer};
+        setWidth(bitmap.getWidth());
+        setHeight(bitmap.getHeight());
+    }
+}

--- a/rajawali/src/main/java/rajawali/materials/textures/utils/ETC2Util.java
+++ b/rajawali/src/main/java/rajawali/materials/textures/utils/ETC2Util.java
@@ -1,0 +1,395 @@
+package rajawali.materials.textures.utils;
+
+import android.annotation.TargetApi;
+import android.opengl.ETC1;
+import android.opengl.ETC1Util;
+import android.opengl.GLES11Ext;
+import android.opengl.GLES30;
+import android.os.Build;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+
+import rajawali.Capabilities;
+import rajawali.util.RajLog;
+
+/**
+ * All in one utility class for ETC2 textures. This performs the same duties as the {@link ETC1} and {@link ETC1Util}
+ * classes, but for the ETC2 format. Can also handle ETC1 textures. For more information see the OpenGL ES 3.0 specification.
+ *
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR2)
+public class ETC2Util {
+
+    /**
+     * The original ETC1 format is also compatible with ETC2 decoders.
+     */
+    public static final int GL_COMPRESSED_ETC1_RGB8_OES = GLES11Ext.GL_ETC1_RGB8_OES;
+
+    /**
+     * The main difference is that the newer version contains three new modes; the ‘T-mode’
+     * and the ‘H-mode’ which are good for sharp chrominance blocks and the ‘Planar’ mode which
+     * is good for smooth blocks.
+     *
+     * NOTE: ETC1 files can be passed to ETC2 decoders as {@link GLES30#GL_COMPRESSED_RGB8_ETC2}.
+     */
+    public static final int GL_COMPRESSED_RGB8_ETC2 = GLES30.GL_COMPRESSED_RGB8_ETC2;
+
+    /**
+     * Same as {@link #GL_COMPRESSED_RGB8_ETC2} with the difference that the values should be interpreted as sRGB-values
+     * instead of RGB values.
+     */
+    public static final int GL_COMPRESSED_SRGB8_ETC2 = GLES30.GL_COMPRESSED_SRGB8_ETC2;
+
+    /**
+     * Encodes RGBA8 data. The RGB part is encoded exactly the same way as {@link #GL_COMPRESSED_RGB8_ETC2}.
+     * The alpha part is encoded separately.
+     */
+    public static final int GL_COMPRESSED_RGBA8_ETC2_EAC = GLES30.GL_COMPRESSED_RGBA8_ETC2_EAC;
+
+    /**
+     * The same as {@link #GL_COMPRESSED_RGBA8_ETC2_EAC} but here the RGB-values (but not the alpha value) should be
+     * interpreted as sRGB-values.
+     */
+    public static final int GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC = GLES30.GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC;
+
+    /**
+     * A one-channel unsigned format. It is similar to the alpha part of {@link #GL_COMPRESSED_SRGB8_ALPHA8_ETC2_EAC}
+     * but not exactly the same - it delivers higher precision. It is possible to make hardware that can decode both
+     * formats with minimal overhead.
+     */
+    public static final int GL_COMPRESSED_R11_EAC = GLES30.GL_COMPRESSED_R11_EAC;
+
+    /**
+     * A two-channel unsigned format. Each channel is decoded exactly as {@link #GL_COMPRESSED_R11_EAC}.
+     */
+    public static final int GL_COMPRESSED_RG11_EAC = GLES30.GL_COMPRESSED_RG11_EAC;
+
+    /**
+     * A one-channel signed format. This is good in situations when it is important to be able to preserve zero
+     * exactly, and still use both positive and negative values. It is designed to be similar enough to
+     * {@link #GL_COMPRESSED_R11_EAC} so that hardware can decode both with minimal overhead, but it is not exactly
+     * the same. For details, see the corresponding sections of the OpenGL ES 3.0 spec.
+     */
+    public static final int GL_COMPRESSED_SIGNED_R11_EAC = GLES30.GL_COMPRESSED_SIGNED_R11_EAC;
+
+    /**
+     * A two-channel signed format. Each channel is decoded exactly as {@link #GL_COMPRESSED_SIGNED_R11_EAC}.
+     */
+    public static final int GL_COMPRESSED_SIGNED_RG11_EAC = GLES30.GL_COMPRESSED_SIGNED_RG11_EAC;
+
+    /**
+     * Very similar to {@link #GL_COMPRESSED_RGB8_ETC2}, but has the ability to represent “punchthrough”-alpha
+     * (completely opaque or transparent). Each block can select to be completely opauqe using one bit. To fit
+     * this bit, there is no individual mode in {@link #GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2}. In other
+     * respects, the opaque blocks are decoded as in {@link #GL_COMPRESSED_RGB8_ETC2}. For the transparent blocks,
+     * one index is reserved to represent transparency, and the decoding of the RGB channels are also affected.
+     * For details, see the corresponding sections of the OpenGL ES 3.0 spec.
+     */
+    public static final int GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = GLES30.GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+
+    /**
+     * The same as {@link #GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2} but should be interpreted as sRGB.
+     */
+    public static final int GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2 = GLES30.GL_COMPRESSED_SRGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+
+    /**
+     * Check if ETC2 texture compression is supported by the active OpenGL ES context.
+     *
+     * @return true if the active OpenGL ES context supports ETC1 texture compression.
+     */
+    public static boolean isETC2Supported() {
+        // If this device is GL ES 3.0 or better, ETC2 is guaranteed to be supported.
+        return (Capabilities.getGLESMajorVersion() >= 3);
+    }
+
+    /**
+     * A utility class encapsulating a compressed ETC2 texture.
+     *
+     * @author Jared Woolston (jwoolston@tenkiv.com)
+     */
+    public static class ETC2Texture {
+
+        private int mCompressionFormat;
+        private int mWidth;
+        private int mHeight;
+        private ByteBuffer mData;
+
+        public ETC2Texture(int type, int width, int height, ByteBuffer data) {
+            mCompressionFormat = type;
+            mWidth = width;
+            mHeight = height;
+            mData = data;
+        }
+
+        /**
+         * Get the ETC2 compression type for this texture.
+         *
+         * @return {@code int} One of the GL_COMPRESSED_* integers for ETC2.
+         */
+        public int getCompressionFormat() {
+            return mCompressionFormat;
+        }
+
+        /**
+         * Get the width of the texture in pixels.
+         *
+         * @return the width of the texture in pixels.
+         */
+        public int getWidth() {
+            return mWidth;
+        }
+
+        /**
+         * Get the height of the texture in pixels.
+         *
+         * @return the width of the texture in pixels.
+         */
+        public int getHeight() {
+            return mHeight;
+        }
+
+        /**
+         * Get the compressed data of the texture.
+         *
+         * @return the texture data.
+         */
+        public ByteBuffer getData() {
+            return mData;
+        }
+    }
+
+    /**
+     * Create a new ETC2Texture from an input stream containing a PKM formatted compressed texture.
+     *
+     * @param input an input stream containing a PKM formatted compressed texture.
+     *
+     * @return an ETC2Texture read from the input stream.
+     * @throws IOException
+     */
+    public static ETC2Texture createTexture(InputStream input) throws IOException {
+        int width = 0;
+        int height = 0;
+        int format = -1;
+        byte[] ioBuffer = new byte[4096];
+
+        // We can use the ETC1 header size as it is the same
+        if (input.read(ioBuffer, 0, ETC1.ETC_PKM_HEADER_SIZE) != ETC1.ETC_PKM_HEADER_SIZE) {
+            throw new IOException("Unable to read PKM file header.");
+        }
+        final ByteBuffer headerBuffer = ByteBuffer.allocateDirect(ETC1.ETC_PKM_HEADER_SIZE)
+            .order(ByteOrder.BIG_ENDIAN);
+        headerBuffer.put(ioBuffer, 0, ETC1.ETC_PKM_HEADER_SIZE).position(0);
+        if (!ETC2.isValid(headerBuffer)) {
+            throw new IOException("Not a PKM file.");
+        }
+        width = ETC2.getWidth(headerBuffer);
+        height = ETC2.getHeight(headerBuffer);
+        format = ETC2.getETC2CompressionType(headerBuffer);
+        final int encodedSize = ETC2.getEncodedDataSize(width, height);
+        final ByteBuffer dataBuffer = ByteBuffer.allocateDirect(encodedSize).order(ByteOrder.BIG_ENDIAN);
+        for (int i = 0; i < encodedSize; ) {
+            int chunkSize = Math.min(ioBuffer.length, encodedSize - i);
+            if (input.read(ioBuffer, 0, chunkSize) != chunkSize) {
+                throw new IOException("Unable to read PKM file data.");
+            }
+            dataBuffer.put(ioBuffer, 0, chunkSize);
+            i += chunkSize;
+        }
+        dataBuffer.position(0);
+        return new ETC2Texture(format, width, height, dataBuffer);
+    }
+
+    /**
+     * Parsing and data utility class for ETC2 textures.
+     *
+     * @author Jared Woolston (jwoolston@tenkiv.com)
+     */
+    public static final class ETC2 {
+
+        /**
+         * The magic sequence for an ETC1 file.
+         */
+        private static final byte ETC1Magic[] = {
+            0x50, //'P'
+            0x4B, //'K'
+            0x4D, //'M'
+            0x20, //' '
+            0x31, //'1'
+            0x30  //'0'
+        };
+
+        /**
+         * The magic sequence for an ETC2 file.
+         */
+        private static final byte ETC2Magic[] = {
+            0x50, //'P'
+            0x4B, //'K'
+            0x4D, //'M'
+            0x20, //' '
+            0x32, //'2'
+            0x30  //'0'
+        };
+
+        /**
+         * File header offsets.
+         */
+        private static final int ETC2_PKM_FORMAT_OFFSET = 6;
+        private static final int ETC2_PKM_ENCODED_WIDTH_OFFSET = 8;
+        private static final int ETC2_PKM_ENCODED_HEIGHT_OFFSET = 10;
+        private static final int ETC2_PKM_WIDTH_OFFSET = 12;
+        private static final int ETC2_PKM_HEIGHT_OFFSET = 14;
+
+        /**
+         * These are the supported PKM format identifiers for the PKM header. The sRGB formats are missing here because I was
+         * not able to get header file information for them. This is the only thing preventing them from being supported.
+         */
+        private static final short ETC1_RGB8_OES = 0x0000;
+        private static final short RGB8_ETC2 = 0x0001;
+        private static final short RGBA8_ETC2_EAC = 0x0003;
+        private static final short RGB8_PUNCHTHROUGH_ALPHA1_ETC2 = 0x0004;
+        private static final short R11_EAC = 0x0005;
+        private static final short RG11_EAC = 0x0006;
+        private static final short SIGNED_R11_EAC = 0x0007;
+        private static final short SIGNED_RG11_EAC = 0x0008;
+
+        /**
+         * Checks the provided file header and determines if this is a valid ETC2 file.
+         *
+         * @param header {@link ByteBuffer} The PKM file header.
+         * @return {@code boolean} True if the file header is valid.
+         */
+        public static boolean isValid(ByteBuffer header) {
+            // First check the ETC2 magic sequence
+            if ((ETC2Magic[0] != header.get(0)) && (ETC2Magic[1] != header.get(1)) && (ETC2Magic[2] != header.get(2))
+                && (ETC2Magic[3] != header.get(3)) && (ETC2Magic[4] != header.get(4)) && (ETC2Magic[5] != header.get(5))) {
+                RajLog.e("ETC2 header failed magic sequence check.");
+                // Check to see if we are ETC1 instead
+                if ((ETC1Magic[0] != header.get(0)) && (ETC1Magic[1] != header.get(1)) && (ETC1Magic[2] != header.get(2))
+                    && (ETC1Magic[3] != header.get(3)) && (ETC1Magic[4] != header.get(4)) && (ETC1Magic[5] != header.get(5))) {
+                    RajLog.e("ETC1 header failed magic sequence check.");
+                    return false;
+                }
+            }
+
+            // Second check the type
+            final short ETC2_FORMAT = header.getShort(ETC2_PKM_FORMAT_OFFSET);
+            switch (ETC2_FORMAT) {
+                case ETC1_RGB8_OES:
+                case RGB8_ETC2:
+                case RGBA8_ETC2_EAC:
+                case RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+                case R11_EAC:
+                case RG11_EAC:
+                case SIGNED_R11_EAC:
+                case SIGNED_RG11_EAC:
+                    break;
+                default:
+                    RajLog.e("ETC2 header failed format check.");
+                    return false;
+            }
+
+            final int encodedWidth = getEncodedWidth(header);
+            final int encodedHeight = getEncodedHeight(header);
+            final int width = getWidth(header);
+            final int height = getHeight(header);
+
+            // Check the width
+            if (encodedWidth < width || (encodedWidth - width) > 4) {
+                RajLog.e("ETC2 header failed width check. Encoded: " + encodedWidth + " Actual: " + width);
+                return false;
+            }
+            // Check the height
+            if (encodedHeight < height || (encodedHeight - height) > 4) {
+                RajLog.e("ETC2 header failed height check. Encoded: " + encodedHeight + " Actual: " + height);
+                return false;
+            }
+
+            // We passed all the checks, return true
+            return true;
+        }
+
+        /**
+         * Retrieves the particular compression format for the ETC2 Texture.
+         *
+         * @param header {@link ByteBuffer} The PKM file header.
+         * @return {@code int} One of the GL_COMPRESSED_* types for ETC2, or -1 if unrecognized.
+         */
+        public static int getETC2CompressionType(ByteBuffer header) {
+            switch (header.getShort(ETC2_PKM_FORMAT_OFFSET)) {
+                case ETC1_RGB8_OES:
+                    return GL_COMPRESSED_ETC1_RGB8_OES;
+                case RGB8_ETC2:
+                    return GL_COMPRESSED_RGB8_ETC2;
+                case RGBA8_ETC2_EAC:
+                    return GL_COMPRESSED_RGBA8_ETC2_EAC;
+                case RGB8_PUNCHTHROUGH_ALPHA1_ETC2:
+                    return GL_COMPRESSED_RGB8_PUNCHTHROUGH_ALPHA1_ETC2;
+                case R11_EAC:
+                    return GL_COMPRESSED_R11_EAC;
+                case RG11_EAC:
+                    return GL_COMPRESSED_RG11_EAC;
+                case SIGNED_R11_EAC:
+                    return SIGNED_R11_EAC;
+                case SIGNED_RG11_EAC:
+                    return SIGNED_RG11_EAC;
+                default:
+                    return -1;
+            }
+        }
+
+        /**
+         * Retrieve the actual texture width in pixels.
+         *
+         * @param header {@link ByteBuffer} The PKM file header.
+         * @return {@code int} The actual texture width.
+         */
+        public static int getWidth(ByteBuffer header) {
+            return (0xFFFF & header.getShort(ETC2_PKM_WIDTH_OFFSET));
+        }
+
+        /**
+         * Retrieve the actual texture height in pixels.
+         *
+         * @param header {@link ByteBuffer} The PKM file header.
+         * @return {@code int} The actual texture height.
+         */
+        public static int getHeight(ByteBuffer header) {
+            return (0xFFFF & header.getShort(ETC2_PKM_HEIGHT_OFFSET));
+        }
+
+        /**
+         * Retrieve the encoded texture width in pixels.
+         *
+         * @param header {@link ByteBuffer} The PKM file header.
+         * @return {@code int} The encoded texture width.
+         */
+        public static int getEncodedWidth(ByteBuffer header) {
+            return (0xFFFF & header.getShort(ETC2_PKM_ENCODED_WIDTH_OFFSET));
+        }
+
+        /**
+         * Retrieve the encoded texture height in pixels.
+         *
+         * @param header {@link ByteBuffer} The PKM file header.
+         * @return {@code int} The encoded texture height.
+         */
+        public static int getEncodedHeight(ByteBuffer header) {
+            return (0xFFFF & header.getShort(ETC2_PKM_ENCODED_HEIGHT_OFFSET));
+        }
+
+        /**
+         * Return the size of the encoded image data (does not include the size of the PKM header).
+         *
+         * @param width {@code int} The actual texture width in pixels.
+         * @param height {@code int} The actual texture height in pixels.
+         * @return {@code int} The number of bytes required to encode this data.
+         */
+        public static int getEncodedDataSize(int width, int height) {
+            return ((((width + 3) & ~3) * ((height + 3) & ~3)) >> 1);
+        }
+    }
+}

--- a/rajawali/src/main/java/rajawali/util/egl/RajawaliEGLConfigChooser.java
+++ b/rajawali/src/main/java/rajawali/util/egl/RajawaliEGLConfigChooser.java
@@ -34,6 +34,7 @@ public class RajawaliEGLConfigChooser implements GLSurfaceView.EGLConfigChooser 
         return usesCoverageAa;
     }
 
+    @Override
     public EGLConfig chooseConfig(EGL10 egl, EGLDisplay display) {
         int[] configSpec = new int[] {
                 EGL10.EGL_RED_SIZE, 5,


### PR DESCRIPTION
Adds ETC2 texture support for GLES 3.0 and better devices. The new class `Etc2Texture` can accomadate both ETC1 and ETC2 textures. Additionally, all rendering surfaces will now automatically select GLES 3.0 if the device supports it, 2.0 otherwise.