### PR TITLE
Numerous Quaternion related fixes

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -417,7 +417,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      */
     public ATransformable3D setRotX(double rotX) {
         mTmpOrientation.setAll(mOrientation);
-        mOrientation.fromEuler(mTmpOrientation.getYaw(false), mTmpOrientation.getPitch(false), rotX);
+        mOrientation.fromEuler(mTmpOrientation.getYaw(), mTmpOrientation.getPitch(), rotX);
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;
@@ -434,7 +434,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      */
     public ATransformable3D setRotY(double rotY) {
         mTmpOrientation.setAll(mOrientation);
-        mOrientation.fromEuler(rotY, mTmpOrientation.getPitch(false), mTmpOrientation.getRoll(false));
+        mOrientation.fromEuler(rotY, mTmpOrientation.getPitch(), mTmpOrientation.getRoll());
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;
@@ -451,7 +451,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      */
     public ATransformable3D setRotZ(double rotZ) {
         mTmpOrientation.setAll(mOrientation);
-        mOrientation.fromEuler(mTmpOrientation.getYaw(false), rotZ, mTmpOrientation.getRoll(false));
+        mOrientation.fromEuler(mTmpOrientation.getYaw(), rotZ, mTmpOrientation.getRoll());
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;
@@ -463,7 +463,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      * @return double The roll Euler angle.
      */
     public double getRotX() {
-        return mOrientation.getRoll(false);
+        return mOrientation.getPitch();
     }
 
     /**
@@ -472,7 +472,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      * @return double The yaw Euler angle.
      */
     public double getRotY() {
-        return mOrientation.getYaw(false);
+        return mOrientation.getYaw();
     }
 
     /**
@@ -481,7 +481,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      * @return double The pitch Euler angle.
      */
     public double getRotZ() {
-        return mOrientation.getPitch(false);
+        return mOrientation.getRoll();
     }
 
     /**

--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -19,6 +19,7 @@ import org.rajawali3d.math.vector.Vector3;
 import org.rajawali3d.renderer.AFrameTask;
 import org.rajawali3d.scenegraph.IGraphNode;
 import org.rajawali3d.scenegraph.IGraphNodeMember;
+import org.rajawali3d.util.RajLog;
 
 public abstract class ATransformable3D extends AFrameTask implements IGraphNodeMember {
     protected final Matrix4 mMMatrix = new Matrix4(); //The model matrix
@@ -655,8 +656,13 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
      * @return A reference to this {@link ATransformable3D} to facilitate chaining.
      */
     public ATransformable3D resetToLookAt(Vector3 upAxis) {
-        mTempVec.subtractAndSet(mPosition, mLookAt);
+        mTempVec.subtractAndSet(mLookAt, mPosition);
+        // In OpenGL, Cameras are defined such that their forward axis is -Z, not +Z like we have defined objects.
+        if (mIsCamera) mTempVec.inverse();
+        RajLog.d(this, "Calculating look at for vectors: Look: " + mTempVec + " Up: " + upAxis);
         mOrientation.lookAt(mTempVec, upAxis);
+        RajLog.d(this, "Orientation: " + mOrientation);
+        RajLog.d(this, "Angles: <" + Math.toDegrees(getRotX()) + ", " + Math.toDegrees(getRotY()) + ", " + Math.toDegrees(getRotZ()) + ">");
         mLookAtValid = true;
         markModelMatrixDirty();
         return this;

--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -48,7 +48,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
 		mScale = new Vector3(1, 1, 1);
 		mOrientation = new Quaternion();
 		mTmpOrientation = new Quaternion();
-        mUpAxis = new Vector3(Vector3.getAxisVector(Vector3.Axis.Y)); //Default to +Y
+        mUpAxis = new Vector3(WorldParameters.UP_AXIS);
 	}
 
     /**

--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -659,10 +659,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
         mTempVec.subtractAndSet(mLookAt, mPosition);
         // In OpenGL, Cameras are defined such that their forward axis is -Z, not +Z like we have defined objects.
         if (mIsCamera) mTempVec.inverse();
-        RajLog.d(this, "Calculating look at for vectors: Look: " + mTempVec + " Up: " + upAxis);
         mOrientation.lookAt(mTempVec, upAxis);
-        RajLog.d(this, "Orientation: " + mOrientation);
-        RajLog.d(this, "Angles: <" + Math.toDegrees(getRotX()) + ", " + Math.toDegrees(getRotY()) + ", " + Math.toDegrees(getRotZ()) + ">");
         mLookAtValid = true;
         markModelMatrixDirty();
         return this;

--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -31,7 +31,7 @@ public abstract class ATransformable3D extends AFrameTask implements IGraphNodeM
 
     protected Vector3 mLookAt; //The look at target
     protected boolean mLookAtValid = false; //Is the look at target up to date?
-    protected boolean mLookAtEnabled = true; //Should we auto enforce look at target?
+    protected boolean mLookAtEnabled; //Should we auto enforce look at target?
     protected boolean mIsCamera; //is this a camera object?
     protected boolean mIsModelMatrixDirty = true; // If true, the model matrix needs to be recalculated.
     protected boolean mInsideGraph = false; //Default to being outside the graph

--- a/rajawali/src/main/java/org/rajawali3d/Camera.java
+++ b/rajawali/src/main/java/org/rajawali3d/Camera.java
@@ -70,7 +70,8 @@ public class Camera extends ATransformable3D {
 
 	public Matrix4 getViewMatrix() {
 		synchronized (mFrustumLock) {
-            // Create an inverted orientation
+            // Create an inverted orientation. This is because the view matrix is the
+            // inverse operation of a model matrix
             mTmpOrientation.setAll(mOrientation);
             mTmpOrientation.inverse();
 

--- a/rajawali/src/main/java/org/rajawali3d/WorldParameters.java
+++ b/rajawali/src/main/java/org/rajawali3d/WorldParameters.java
@@ -1,0 +1,73 @@
+package org.rajawali3d;
+
+import org.rajawali3d.math.vector.Vector3;
+
+/**
+ * Collection of world global parameters. These parameters are constant across all scenes. This class is intended to be
+ * read only after setup, and so does not include any thread safety mechanisms in the interest of speed. Extreme care
+ * must be taken if you desire to modify anything in this class while other threads are actively using it.
+ *
+ * @author Jared Woolston (jwoolston@idealcorp.com)
+ */
+public final class WorldParameters {
+
+    private static final Vector3 TEMP_VECTOR = new Vector3();
+
+    /**
+     * Global Right Axis. Defaults to OpenGL +X axis. It is not safe to modify this {@link Vector3} directly.
+     * Instead, use {@link #setWorldAxes(Vector3, Vector3, Vector3)}.
+     */
+    public static final Vector3 RIGHT_AXIS = Vector3.X.clone();
+
+    /**
+     * Global Negative Right Axis. Defaults to OpenGL -X axis. It is not safe to modify this {@link Vector3} directly.
+     * Instead, use {@link #setWorldAxes(Vector3, Vector3, Vector3)}.
+     */
+    public static final Vector3 NEG_RIGHT_AXIS = Vector3.NEG_X.clone();
+
+    /**
+     * Global Up Axis. Defaults to OpenGL +Y axis. It is not safe to modify this {@link Vector3} directly.
+     * Instead, use {@link #setWorldAxes(Vector3, Vector3, Vector3)}.
+     */
+    public static final Vector3 UP_AXIS = Vector3.Y.clone();
+
+    /**
+     * Global Negative Up Axis. Defaults to OpenGL -Y axis. It is not safe to modify this {@link Vector3} directly.
+     * Instead, use {@link #setWorldAxes(Vector3, Vector3, Vector3)}.
+     */
+    public static final Vector3 NEG_UP_AXIS = Vector3.NEG_Y.clone();
+
+    /**
+     * Global Forward Axis. Defaults to OpenGL +Z axis. It is not safe to modify this {@link Vector3} directly.
+     * Instead, use {@link #setWorldAxes(Vector3, Vector3, Vector3)}.
+     */
+    public static final Vector3 FORWARD_AXIS = Vector3.Z.clone();
+
+    /**
+     * Global Negative Forward Axis. Defaults to OpenGL -Z axis. It is not safe to modify this {@link Vector3} directly.
+     * Instead, use {@link #setWorldAxes(Vector3, Vector3, Vector3)}.
+     */
+    public static final Vector3 NEG_FORWARD_AXIS = Vector3.NEG_Z.clone();
+
+    /**
+     * Sets the world axis values after checking that they are all orthogonal to each other. The check performed
+     * is to verify that the cross product between {@code right} and {@code up} is equivilant to {@code forward}
+     * withing 1ppm error on each component.
+     *
+     * @param right {@link Vector3} The desired right vector. Should be normalized.
+     * @param up {@link Vector3} The desired up vector. Should be normalized.
+     * @param forward {@link Vector3} The desired forward vector. Should be normalized.
+     */
+    public static void setWorldAxes(Vector3 right, Vector3 up, Vector3 forward) {
+        TEMP_VECTOR.crossAndSet(right, up);
+        if (!TEMP_VECTOR.equals(forward, 1e-6)) {
+            throw new IllegalArgumentException("World axes must be orthogonal.");
+        }
+        RIGHT_AXIS.setAll(right);
+        NEG_RIGHT_AXIS.setAll(RIGHT_AXIS).inverse();
+        UP_AXIS.setAll(up);
+        NEG_UP_AXIS.setAll(UP_AXIS).inverse();
+        FORWARD_AXIS.setAll(forward);
+        NEG_FORWARD_AXIS.setAll(FORWARD_AXIS).inverse();
+    }
+}

--- a/rajawali/src/main/java/org/rajawali3d/WorldParameters.java
+++ b/rajawali/src/main/java/org/rajawali3d/WorldParameters.java
@@ -54,9 +54,9 @@ public final class WorldParameters {
      * is to verify that the cross product between {@code right} and {@code up} is equivilant to {@code forward}
      * withing 1ppm error on each component.
      *
-     * @param right {@link Vector3} The desired right vector. Should be normalized.
-     * @param up {@link Vector3} The desired up vector. Should be normalized.
-     * @param forward {@link Vector3} The desired forward vector. Should be normalized.
+     * @param right {@link Vector3} The desired right vector. Must be normalized.
+     * @param up {@link Vector3} The desired up vector. Must be normalized.
+     * @param forward {@link Vector3} The desired forward vector. Must be normalized.
      */
     public static void setWorldAxes(Vector3 right, Vector3 up, Vector3 forward) {
         TEMP_VECTOR.crossAndSet(right, up);

--- a/rajawali/src/main/java/org/rajawali3d/lights/DirectionalLight.java
+++ b/rajawali/src/main/java/org/rajawali3d/lights/DirectionalLight.java
@@ -49,8 +49,6 @@ public class DirectionalLight extends ALight {
         mDirectionVec.setAll(mForwardAxis);
         // Rotate the vector based on our orientation
         mDirectionVec.rotateBy(mOrientation);
-        // We need to invert the direction - to be honest not sure why
-        mDirectionVec.inverse();
         return this;
     }
 }

--- a/rajawali/src/main/java/org/rajawali3d/lights/DirectionalLight.java
+++ b/rajawali/src/main/java/org/rajawali3d/lights/DirectionalLight.java
@@ -12,44 +12,45 @@
  */
 package org.rajawali3d.lights;
 
+import org.rajawali3d.ATransformable3D;
 import org.rajawali3d.math.vector.Vector3;
-import org.rajawali3d.math.vector.Vector3.Axis;
 
 public class DirectionalLight extends ALight {
 	protected double[] mDirection = new double[3];
-	protected double[] mRotationMatrix = new double[16];
 	protected Vector3 mDirectionVec = new Vector3();
-	final protected Vector3 mForwardAxis = Vector3.getAxisVector(Axis.Z);
+    // We are defining Rajawali Engine lights to be emitting from their +Z side. We are using a
+    // Forward axis since that is what the look at orientation will be effecting.
+	final protected Vector3 mForwardAxis = Vector3.getAxisVector(Vector3.Axis.Z);
 
 	public DirectionalLight() {
 		super(DIRECTIONAL_LIGHT);
-		setRotY(180);
 	}
 
 	public DirectionalLight(double xDir, double yDir, double zDir) {
-		super(DIRECTIONAL_LIGHT);
-		setDirection(xDir, yDir, zDir);
-	}
-
-	public void setDirection(double x, double y, double z) {
-		setLookAt(x, y, z);
-        mDirectionVec.setAll(mForwardAxis);
-        mDirectionVec.rotateBy(mOrientation);
-        mDirectionVec.inverse();
-        mDirection[0] = (float) mDirectionVec.x;
-        mDirection[1] = (float) mDirectionVec.y;
-        mDirection[2] = (float) mDirectionVec.z;
-	}
-
-	public void setDirection(Vector3 dir) {
-		setDirection(dir.x, dir.y, dir.z);
+		this();
+		setLookAt(xDir, yDir, zDir);
 	}
 
 	public double[] getDirection() {
+        mDirection[0] = mDirectionVec.x;
+        mDirection[1] = mDirectionVec.y;
+        mDirection[2] = mDirectionVec.z;
 		return mDirection;
 	}
 	
 	public Vector3 getDirectionVector() {
 		return mDirectionVec;
 	}
+
+    @Override
+    public ATransformable3D resetToLookAt(Vector3 upAxis) {
+        super.resetToLookAt(upAxis);
+        // We want to rotate the forward axis since that's what Quaternion.lookAt() affects
+        mDirectionVec.setAll(mForwardAxis);
+        // Rotate the vector based on our orientation
+        mDirectionVec.rotateBy(mOrientation);
+        // We need to invert the direction - to be honest not sure why
+        mDirectionVec.inverse();
+        return this;
+    }
 }

--- a/rajawali/src/main/java/org/rajawali3d/lights/SpotLight.java
+++ b/rajawali/src/main/java/org/rajawali3d/lights/SpotLight.java
@@ -30,7 +30,7 @@ public class SpotLight extends DirectionalLight {
 
 	public SpotLight(float xDir, float yDir, float zDir) {
 		this();
-		setDirection(xDir, yDir, zDir);
+		setLookAt(xDir, yDir, zDir);
 	}
 
 	public void setAttenuation(float range, float constant, float linear, float quadratic) {

--- a/rajawali/src/main/java/org/rajawali3d/loader/fbx/LoaderFBX.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/fbx/LoaderFBX.java
@@ -16,6 +16,31 @@ import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.Color;
 
+import org.rajawali3d.Camera;
+import org.rajawali3d.Object3D;
+import org.rajawali3d.lights.ALight;
+import org.rajawali3d.lights.DirectionalLight;
+import org.rajawali3d.lights.PointLight;
+import org.rajawali3d.lights.SpotLight;
+import org.rajawali3d.loader.AMeshLoader;
+import org.rajawali3d.loader.ParsingException;
+import org.rajawali3d.loader.fbx.FBXValues.Connections.Connect;
+import org.rajawali3d.loader.fbx.FBXValues.FBXColor4;
+import org.rajawali3d.loader.fbx.FBXValues.FBXFloatBuffer;
+import org.rajawali3d.loader.fbx.FBXValues.FBXIntBuffer;
+import org.rajawali3d.loader.fbx.FBXValues.FBXMatrix;
+import org.rajawali3d.loader.fbx.FBXValues.Objects.FBXMaterial;
+import org.rajawali3d.loader.fbx.FBXValues.Objects.Model;
+import org.rajawali3d.materials.Material;
+import org.rajawali3d.materials.methods.DiffuseMethod;
+import org.rajawali3d.materials.methods.SpecularMethod;
+import org.rajawali3d.materials.textures.ATexture.TextureException;
+import org.rajawali3d.materials.textures.Texture;
+import org.rajawali3d.math.vector.Vector2;
+import org.rajawali3d.math.vector.Vector3;
+import org.rajawali3d.renderer.RajawaliRenderer;
+import org.rajawali3d.util.RajLog;
+
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -29,31 +54,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Stack;
-
-import org.rajawali3d.Camera;
-import org.rajawali3d.Object3D;
-import org.rajawali3d.lights.ALight;
-import org.rajawali3d.lights.DirectionalLight;
-import org.rajawali3d.lights.PointLight;
-import org.rajawali3d.lights.SpotLight;
-import org.rajawali3d.materials.Material;
-import org.rajawali3d.materials.methods.DiffuseMethod;
-import org.rajawali3d.materials.methods.SpecularMethod;
-import org.rajawali3d.materials.textures.ATexture.TextureException;
-import org.rajawali3d.materials.textures.Texture;
-import org.rajawali3d.math.vector.Vector2;
-import org.rajawali3d.math.vector.Vector3;
-import org.rajawali3d.loader.AMeshLoader;
-import org.rajawali3d.loader.ParsingException;
-import org.rajawali3d.loader.fbx.FBXValues.Connections.Connect;
-import org.rajawali3d.loader.fbx.FBXValues.FBXColor4;
-import org.rajawali3d.loader.fbx.FBXValues.FBXFloatBuffer;
-import org.rajawali3d.loader.fbx.FBXValues.FBXIntBuffer;
-import org.rajawali3d.loader.fbx.FBXValues.FBXMatrix;
-import org.rajawali3d.loader.fbx.FBXValues.Objects.FBXMaterial;
-import org.rajawali3d.loader.fbx.FBXValues.Objects.Model;
-import org.rajawali3d.renderer.RajawaliRenderer;
-import org.rajawali3d.util.RajLog;
 public class LoaderFBX extends AMeshLoader {
 	private static final char COMMENT = ';';
 	private static final String OBJECT_TYPE = "ObjectType:";
@@ -232,7 +232,7 @@ public class LoaderFBX extends AMeshLoader {
 			return light;			
 			
 		case ALight.DIRECTIONAL_LIGHT:		//Area
-			DirectionalLight lD = new DirectionalLight(0,-1,0);  //TODO calculate direction based on position and rotation
+			DirectionalLight lD = new DirectionalLight();  //TODO calculate direction based on position and rotation
 			lD.setPosition(l.properties.lclTranslation);
 			lD.setX(lD.getX() * -1f);
 			lD.setRotation(l.properties.lclRotation);

--- a/rajawali/src/main/java/org/rajawali3d/math/Quaternion.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/Quaternion.java
@@ -358,16 +358,17 @@ public final class Quaternion {
 	 * @return A reference to this {@link Quaternion} to facilitate chaining.
 	 */
 	public Quaternion fromRotationBetween(final Vector3 v1, final Vector3 v2) {
+        RajLog.d(this, "Computing rotation between: " + v1 + " and " + v2);
 		final double dot = MathUtil.clamp(v1.dot(v2), -1f, 1f);
         final double dotError = 1.0 - Math.abs(dot);
         if (dotError <= 1e-6) {
             // The look and up vectors are parallel/anti-parallel
             if (dot < 0) {
                 // The look and up vectors are parallel but opposite direction
-                mTmpVec3.crossAndSet(Vector3.X, v1);
+                mTmpVec3.crossAndSet(WorldParameters.RIGHT_AXIS, v1);
                 if (mTmpVec3.length() < 1e-6) {
                     // Vectors were co-linear, pick another
-                    mTmpVec3.crossAndSet(Vector3.Y, v1);
+                    mTmpVec3.crossAndSet(WorldParameters.UP_AXIS, v1);
                 }
                 mTmpVec3.normalize();
                 return fromAngleAxis(mTmpVec3, 180.0);
@@ -378,7 +379,7 @@ public final class Quaternion {
         }
 
 		final double angle = Math.toDegrees(Math.acos(dot));
-		return fromAngleAxis(v1.y * v2.z - v1.z * v2.y, v1.z * v2.x - v1.x * v2.z, 
+        return fromAngleAxis(v1.y * v2.z - v1.z * v2.y, v1.z * v2.x - v1.x * v2.z,
 				v1.x * v2.y - v1.y * v2.x, angle);
 	}
 	
@@ -1052,13 +1053,12 @@ public final class Quaternion {
     public Quaternion lookAt(Vector3 lookAt, Vector3 upDirection) {
         mTmpVec1.setAll(lookAt);
         mTmpVec2.setAll(upDirection);
+        // Vectors are parallel/anti-parallel if their dot product magnitude and length product are equal
         final double dotProduct = Vector3.dot(lookAt, upDirection);
         final double dotError = Math.abs(Math.abs(dotProduct) - (lookAt.length() * upDirection.length()));
         if (dotError <= 1e-6) {
             // The look and up vectors are parallel
             mTmpVec2.normalize();
-            // The look and up vectors are parallel in the same direction
-            RajLog.d(this, "Computing rotation between world up axis and " + mTmpVec1);
             fromRotationBetween(WorldParameters.FORWARD_AXIS, mTmpVec1);
             return this;
         }

--- a/rajawali/src/main/java/org/rajawali3d/math/Quaternion.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/Quaternion.java
@@ -468,8 +468,8 @@ public final class Quaternion {
 	 */
 	public Vector3 multiply(final Vector3 vector) {
 		mTmpVec3.setAll(x, y, z);
-		mTmpVec1 = Vector3.crossAndCreate(mTmpVec3, vector);
-		mTmpVec2 = Vector3.crossAndCreate(mTmpVec3, mTmpVec1);
+        mTmpVec1.crossAndSet(mTmpVec3, vector);
+		mTmpVec2.crossAndSet(mTmpVec3, mTmpVec1);
 		mTmpVec1.multiply(2.0 * w);
 		mTmpVec2.multiply(2.0);
 

--- a/rajawali/src/main/java/org/rajawali3d/math/vector/Vector3.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/vector/Vector3.java
@@ -52,6 +52,18 @@ public class Vector3 {
     /**
      * DO NOT EVER MODIFY THE VALUES OF THIS VECTOR
      */
+    public static final Vector3 NEG_X = new Vector3(-1, 0, 0);
+    /**
+     * DO NOT EVER MODIFY THE VALUES OF THIS VECTOR
+     */
+    public static final Vector3 NEG_Y = new Vector3(0, -1, 0);
+    /**
+     * DO NOT EVER MODIFY THE VALUES OF THIS VECTOR
+     */
+    public static final Vector3 NEG_Z = new Vector3(0, 0, -1);
+    /**
+     * DO NOT EVER MODIFY THE VALUES OF THIS VECTOR
+     */
     public static final Vector3 ZERO = new Vector3(0, 0, 0);
     /**
      * DO NOT EVER MODIFY THE VALUES OF THIS VECTOR
@@ -1206,6 +1218,19 @@ public class Vector3 {
      */
     public boolean equals(final Vector3 obj) {
         return obj.x == x && obj.y == y && obj.z == z;
+    }
+
+    /**
+     * Does a component by component comparison of this {@link Vector3} and the specified {@link Vector3}
+     * with an error parameter and returns the result.
+     *
+     * @param obj {@link Vector3} to compare with this one.
+     * @param error {@code double} The maximum allowable difference to be considered equal.
+     *
+     * @return boolean True if this {@link Vector3}'s components match with the components of the input.
+     */
+    public boolean equals(final Vector3 obj, double error) {
+        return (Math.abs(obj.x - x) <= error) && (Math.abs(obj.y - y) <= error) && (Math.abs(obj.y - y) <= error);
     }
 
     /*

--- a/rajawali/src/main/java/org/rajawali3d/math/vector/Vector3.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/vector/Vector3.java
@@ -582,40 +582,24 @@ public class Vector3 {
      * @param vecs Array of {@link Vector3} objects to be ortho-normalized.
      */
     public static void orthoNormalize(Vector3[] vecs) {
-        final Vector3 accum = new Vector3(0.0, 0.0, 0.0);
         for (int i = 0; i < vecs.length; ++i) {
-            accum.setAll(0.0, 0.0, 0.0);
-
-            for (int j = 0; j < i; ++j)
-                accum.add(Vector3.projectAndCreate(vecs[i], vecs[j]));
-
-            vecs[i].subtract(accum).normalize();
+            vecs[i].normalize();
+            for (int j = i + 1; j < vecs.length; ++j) {
+                vecs[j].subtract(Vector3.projectAndCreate(vecs[j], vecs[i]));
+            }
         }
     }
 
     /**
-     * Applies Gram-Schmitt Ortho-normalization to the given two input {@link Vector3} objects.
-     * This is a more efficient, specialized case for handling a pair of vectors.
+     * Efficient Gram-Schmitt Ortho-normalization for the special case of 2 vectors.
      *
-     * @param vec1 The first {@link Vector3} object to be ortho-normalized.
-     * @param vec2 The first {@link Vector3} object to be ortho-normalized.
+     * @param v1 The first {@link Vector3} object to be ortho-normalized.
+     * @param v2 The second {@link Vector3}. {@link Vector3} object to be ortho-normalized.
      */
-    public static void orthoNormalize(Vector3 vec1, Vector3 vec2) {
-        final Vector3 accum = new Vector3(0.0, 0.0, 0.0);
-
-        // Normalize vec1
-        accum.setAll(0.0, 0.0, 0.0);
-        accum.add(Vector3.projectAndCreate(vec1, vec1));
-        accum.add(Vector3.projectAndCreate(vec1, vec2));
-        vec1.subtract(accum).normalize();
-
-        // Normalize vec2
-        accum.setAll(0.0, 0.0, 0.0);
-
-        accum.add(Vector3.projectAndCreate(vec2, vec1));
-        accum.add(Vector3.projectAndCreate(vec2, vec2));
-
-        vec2.subtract(accum).normalize();
+    public static void orthoNormalize(Vector3 v1, Vector3 v2) {
+        v1.normalize();
+        v2.subtract(Vector3.projectAndCreate(v2, v1));
+        v2.normalize();
     }
 
     /**


### PR DESCRIPTION
Part of Issue #1376 required fixes to the Quaternion class. Most notably, the degenerate case of the look vector being parallel/anti-parallel to the up vector was not being handled. Additionally, in ATransformable3D the look vector was being miscalculated, preventing the detection of the look vector being anti-parallel to the up vector.