### PR TITLE
Load all AWD material attributes; specularity/specular map, normal map, diffuse and ambient textures/levels/colors, etc

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/loader/LoaderAWD.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/LoaderAWD.java
@@ -715,6 +715,7 @@ public class LoaderAWD extends AMeshLoader {
 				break;
 			case TYPE_NR:
 				attrValue = mPropPrecision ? readDouble() : readFloat();
+				break;
 			default:
 				RajLog.e("Skipping unknown attribute (" + attrType + ")");
 				skip(attrLength);

--- a/rajawali/src/main/java/org/rajawali3d/loader/awd/BlockMeshInstance.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/awd/BlockMeshInstance.java
@@ -43,7 +43,7 @@ public class BlockMeshInstance extends AExportableBlockParser {
 					|| !(geomHeader.parser instanceof ABaseObjectBlockParser))
 				throw new ParsingException("Invalid block reference.");
 
-			mGeometry = ((ABaseObjectBlockParser) geomHeader.parser).getBaseObject3D().clone();
+			mGeometry = ((ABaseObjectBlockParser) geomHeader.parser).getBaseObject3D().clone(false, true);
 			mGeometry.setName(mSceneGraphBlock.lookupName);
 		}
 
@@ -77,10 +77,16 @@ public class BlockMeshInstance extends AExportableBlockParser {
 		// Set rotation
 		mGeometry.setOrientation(new Quaternion().fromMatrix(matrix));
 
-		mGeometry.setMaterial(materials[0]);
+		int m = 0;
+
+		if(!mGeometry.isContainer())
+			mGeometry.setMaterial(materials[m++]);
+
+		for(int i = 0; i < mGeometry.getNumChildren(); i++)
+			mGeometry.getChildAt(i).setMaterial(materials[Math.min(materials.length-1, m++)]);
 
 		// FIXME This is a hack to get around the fact that setting the color on the material does not work right now.
-		mGeometry.setColor(mGeometry.getMaterial().getColor());
+		//mGeometry.setColor(mGeometry.getMaterial().getColor());
 
 		dis.skip(blockHeader.blockEnd - dis.getPosition());
 	}

--- a/rajawali/src/main/java/org/rajawali3d/loader/awd/BlockSimpleMaterial.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/awd/BlockSimpleMaterial.java
@@ -1,15 +1,23 @@
 package org.rajawali3d.loader.awd;
 
 import java.util.HashMap;
+import java.util.UUID;
 
-import org.rajawali3d.materials.Material;
-import org.rajawali3d.materials.textures.Texture;
 import org.rajawali3d.loader.LoaderAWD.AWDLittleEndianDataInputStream;
 import org.rajawali3d.loader.LoaderAWD.AwdProperties;
 import org.rajawali3d.loader.LoaderAWD.BlockHeader;
 import org.rajawali3d.loader.ParsingException;
 import org.rajawali3d.loader.awd.exceptions.NotParsableException;
+import org.rajawali3d.materials.Material;
+import org.rajawali3d.materials.methods.DiffuseMethod;
+import org.rajawali3d.materials.methods.SpecularMethod;
+import org.rajawali3d.materials.textures.NormalMapTexture;
+import org.rajawali3d.materials.textures.SpecularMapTexture;
+import org.rajawali3d.materials.textures.Texture;
 import org.rajawali3d.util.RajLog;
+
+import android.graphics.Bitmap;
+import android.graphics.Color;
 import android.util.SparseArray;
 
 /**
@@ -67,26 +75,26 @@ public class BlockSimpleMaterial extends ATextureBlockParser {
 		EXPECTED_PROPS = new SparseArray<Short>();
 		EXPECTED_PROPS.put(PROP_COLOR, AWDLittleEndianDataInputStream.TYPE_UINT32);
 		EXPECTED_PROPS.put(PROP_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
-		// EXPECTED_PROPS.put(PROP_NORMAL_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
-		// EXPECTED_PROPS.put(PROP_SPEZIAL_ID, AWDLittleEndianDataInputStream.TYPE_UINT8);
-		// EXPECTED_PROPS.put(PROP_SMOOTH, AWDLittleEndianDataInputStream.TYPE_BOOL);
-		// EXPECTED_PROPS.put(PROP_MIPMAP, AWDLittleEndianDataInputStream.TYPE_BOOL);
-		// EXPECTED_PROPS.put(PROP_BOTH_SIDES, AWDLittleEndianDataInputStream.TYPE_BOOL);
-		// EXPECTED_PROPS.put(PROP_PRE_MULTIPLIED, AWDLittleEndianDataInputStream.TYPE_BOOL);
-		// EXPECTED_PROPS.put(PROP_BLEND_MODE, AWDLittleEndianDataInputStream.TYPE_UINT8);
+		EXPECTED_PROPS.put(PROP_NORMAL_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
+		EXPECTED_PROPS.put(PROP_SPEZIAL_ID, AWDLittleEndianDataInputStream.TYPE_UINT8);
+		EXPECTED_PROPS.put(PROP_SMOOTH, AWDLittleEndianDataInputStream.TYPE_BOOL);
+		EXPECTED_PROPS.put(PROP_MIPMAP, AWDLittleEndianDataInputStream.TYPE_BOOL);
+		EXPECTED_PROPS.put(PROP_BOTH_SIDES, AWDLittleEndianDataInputStream.TYPE_BOOL);
+		EXPECTED_PROPS.put(PROP_PRE_MULTIPLIED, AWDLittleEndianDataInputStream.TYPE_BOOL);
+		EXPECTED_PROPS.put(PROP_BLEND_MODE, AWDLittleEndianDataInputStream.TYPE_UINT8);
 		EXPECTED_PROPS.put(PROP_ALPHA, AWDLittleEndianDataInputStream.TYPE_NR);
 		EXPECTED_PROPS.put(PROP_ALPHA_BLENDING, AWDLittleEndianDataInputStream.TYPE_BOOL);
 		EXPECTED_PROPS.put(PROP_BINARY_ALPHA_THRESHOLD, AWDLittleEndianDataInputStream.TYPE_NR);
 		EXPECTED_PROPS.put(PROP_REPEAT, AWDLittleEndianDataInputStream.TYPE_BOOL);
-		// EXPECTED_PROPS.put(PROP_DIFFUSE_LEVEL, AWDLittleEndianDataInputStream.TYPE_NR);
-		// EXPECTED_PROPS.put(PROP_AMBIENT_LEVEL, AWDLittleEndianDataInputStream.TYPE_NR);
-		// EXPECTED_PROPS.put(PROP_AMBIENT_COLOR, AWDLittleEndianDataInputStream.TYPE_UINT32);
-		// EXPECTED_PROPS.put(PROP_AMBIENT_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
-		// EXPECTED_PROPS.put(PROP_SPECULAR_LEVEL, AWDLittleEndianDataInputStream.TYPE_NR);
-		// EXPECTED_PROPS.put(PROP_SPECULAR_GLOSS, AWDLittleEndianDataInputStream.TYPE_NR);
-		// EXPECTED_PROPS.put(PROP_SPECULAR_COLOR, AWDLittleEndianDataInputStream.TYPE_UINT32);
-		// EXPECTED_PROPS.put(PROP_SPECULAR_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
-		// EXPECTED_PROPS.put(PROP_LIGHT_PICKER, AWDLittleEndianDataInputStream.TYPE_BADDR);
+		EXPECTED_PROPS.put(PROP_DIFFUSE_LEVEL, AWDLittleEndianDataInputStream.TYPE_NR);
+		EXPECTED_PROPS.put(PROP_AMBIENT_LEVEL, AWDLittleEndianDataInputStream.TYPE_NR);
+		EXPECTED_PROPS.put(PROP_AMBIENT_COLOR, AWDLittleEndianDataInputStream.TYPE_UINT32);
+		EXPECTED_PROPS.put(PROP_AMBIENT_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
+		EXPECTED_PROPS.put(PROP_SPECULAR_LEVEL, AWDLittleEndianDataInputStream.TYPE_NR);
+		EXPECTED_PROPS.put(PROP_SPECULAR_GLOSS, AWDLittleEndianDataInputStream.TYPE_NR);
+		EXPECTED_PROPS.put(PROP_SPECULAR_COLOR, AWDLittleEndianDataInputStream.TYPE_UINT32);
+		EXPECTED_PROPS.put(PROP_SPECULAR_TEXTURE, AWDLittleEndianDataInputStream.TYPE_BADDR);
+		EXPECTED_PROPS.put(PROP_LIGHT_PICKER, AWDLittleEndianDataInputStream.TYPE_BADDR);
 	}
 
 	protected Material mMaterial;
@@ -138,31 +146,107 @@ public class BlockSimpleMaterial extends ATextureBlockParser {
 
 		mMaterial = new Material();
 
+		long	diffuseTexture = 0, ambientTexture = 0,
+				diffuseColor = 0;
+
+		// remove any chars that will break shader compile
+		String cleanName = cleanName(mLookupName);
+
 		switch (mMaterialType) {
 		case TYPE_COLOR:
 			// default to 0xcccccc per AWD implementation
-			final long color = (Long) properties.get((short) 1, 0xcccccc);
+			diffuseColor = (Long) properties.get((short) 1, 0xccccccl);
 			final float[] colorFloat = new float[4];
-			colorFloat[0] = ((color >> 16) & 0xff) / 255.0f;
-			colorFloat[1] = ((color >> 8) & 0xff) / 255.0f;
-			colorFloat[2] = (color & 0xff) / 255.0f;
+			colorFloat[0] = ((diffuseColor >> 16) & 0xff) / 255.0f;
+			colorFloat[1] = ((diffuseColor >> 8) & 0xff) / 255.0f;
+			colorFloat[2] = (diffuseColor & 0xff) / 255.0f;
 			colorFloat[3] = (((int) ((Double) properties.get(PROP_ALPHA, 1.0d) * 0xff)) & 0xff) / 255.0f;
 			mMaterial.setColor(colorFloat);
 			break;
 		case TYPE_TEXTURE:
-			final long textureId = (Long) properties.get(PROP_TEXTURE, 0L);
-			if (textureId == 0)
+			diffuseTexture = (Long) properties.get(PROP_TEXTURE, 0L);
+			ambientTexture = (Long) properties.get(PROP_AMBIENT_TEXTURE, 0L);
+
+			if(diffuseTexture == 0 && ambientTexture == 0)
 				throw new ParsingException("Texture ID can not be 0, document corrupt or unsupported version.");
 
-			final BlockHeader lookupHeader = blockHeader.blockHeaders.get((short) textureId);
-			if (lookupHeader == null || lookupHeader.parser == null
-					|| !(lookupHeader.parser instanceof BlockBitmapTexture))
-				throw new ParsingException("Invalid block reference.");
+			if(diffuseTexture > 0)
+				mMaterial.addTexture(new Texture(cleanName + diffuseTexture, lookup(blockHeader, diffuseTexture)));
 
-			mMaterial.addTexture(new Texture(mLookupName, ((BlockBitmapTexture) lookupHeader.parser).mBitmap));
+			if(ambientTexture > 0)
+				mMaterial.addTexture(new Texture(cleanName + ambientTexture, lookup(blockHeader, ambientTexture)));
+
+			mMaterial.setColorInfluence(0);
+
 			break;
 		}
 
+		// either material type can have specular and/or normal maps
+		long specularTexture = (Long) properties.get(PROP_SPECULAR_TEXTURE, 0L);
+		long normalTexture = (Long) properties.get(PROP_NORMAL_TEXTURE, 0L);
+
+		// either material type can have settings for diffuse, ambient, specular lighting
+		double diffuseLevel = (Double) properties.get(PROP_DIFFUSE_LEVEL, 1.0d);
+
+		long ambientColor = (Long) properties.get(PROP_AMBIENT_COLOR, (long)Color.WHITE);
+		double ambientLevel = (Double) properties.get(PROP_AMBIENT_LEVEL, 1.0d);
+
+		long specularColor = (Long) properties.get(PROP_SPECULAR_COLOR, (long)Color.WHITE);
+		double specularGloss = (Double) properties.get(PROP_SPECULAR_GLOSS, 50.0D);
+		double specularLevel = (Double) properties.get(PROP_SPECULAR_LEVEL, 1.0d);
+
+		if(specularTexture > 0)
+			mMaterial.addTexture(new SpecularMapTexture(cleanName + specularTexture, lookup(blockHeader, specularTexture)));
+
+		if(normalTexture > 0)
+			mMaterial.addTexture(new NormalMapTexture(cleanName + normalTexture, lookup(blockHeader, normalTexture)));
+
+		// ambient 1.0 is default, washes-out object; assume < 1 is intended
+		ambientLevel = (ambientLevel < 1.0 ? ambientLevel : 0.0);
+
+		mMaterial.setAmbientIntensity(ambientLevel, ambientLevel, ambientLevel);
+		mMaterial.setAmbientColor((int)ambientColor);
+
+		if(diffuseLevel > 0) // always 1.0 in current AWD implementation
+			mMaterial.setDiffuseMethod(new DiffuseMethod.Lambert());
+
+		if(specularLevel > 0)
+		{
+			SpecularMethod.Phong phong = new SpecularMethod.Phong();
+
+			phong.setSpecularColor((int)specularColor);
+			phong.setShininess((float)specularGloss);
+			phong.setIntensity((float)specularLevel);
+
+			mMaterial.setSpecularMethod(phong);
+		}
+
+		// don't enable lighting if specular and diffuse are absent, otherwise enable
+		if(diffuseLevel > 0 || specularLevel > 0)
+			mMaterial.enableLighting(true);
 	}
 
+	private Bitmap lookup(BlockHeader blockHeader, long texref) throws ParsingException
+	{
+		final BlockHeader lookupHeader = blockHeader.blockHeaders.get((short) texref);
+
+		if (lookupHeader == null || lookupHeader.parser == null
+				|| !(lookupHeader.parser instanceof BlockBitmapTexture))
+			throw new ParsingException("Invalid block reference.");
+
+		return ((BlockBitmapTexture) lookupHeader.parser).mBitmap;
+	}
+
+	private final static String TEX_PREFIX = "TEX_";
+
+	private String cleanName(String name)
+	{
+		// if null, force generation of a new and valid name
+		String clean = (name == null ? "" : name.replaceAll("\\W", ""));
+
+		if(clean.length() == 0 || Character.isDigit(clean.charAt(0)))
+			clean = TEX_PREFIX + UUID.randomUUID().toString().replaceAll("\\W", "");
+
+		return clean;
+	}
 }


### PR DESCRIPTION
Loads all material attributes from AWD file. The assignment of materials to child objects (where present) follows the implementation in the AwayBuilder source: assign sequentially and repeat the last material in the case where there are additional objects. Also adds a missing break in LoaderAWD switch.