### PR TITLE
Fixes leaks with managers (#1336)

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/AResourceManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/AResourceManager.java
@@ -40,7 +40,19 @@ public abstract class AResourceManager extends AFrameTask {
 	 */
 	public void registerRenderer(RajawaliRenderer renderer)
 	{
-		mRenderers.add(renderer);
+        boolean alreadyRegistered = false;
+
+        for (int i=0;i<mRenderers.size();i++) {
+            if (renderer == mRenderers.get(i)) {
+                alreadyRegistered = true;
+                break;
+            }
+        }
+
+        if (!alreadyRegistered) {
+            mRenderers.add(renderer);            
+        }
+        
 		mRenderer = renderer;
 	}
 


### PR DESCRIPTION
Right now renderers are being registered twice in both TextureManager and MaterialManager: on render constructor and in onSurfaceCreated. They are also re-added on subsequent calls to onSurfaceCreated. 