### PR TITLE
Fix for Issue #1355 -- Animated GIF & Alpha Channel.

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/AnimatedGIFTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/AnimatedGIFTexture.java
@@ -13,6 +13,7 @@
 package org.rajawali3d.materials.textures;
 
 import android.content.Context;
+import android.graphics.Color;
 import android.graphics.Bitmap;
 import android.graphics.Bitmap.Config;
 import android.graphics.Canvas;

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/AnimatedGIFTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/AnimatedGIFTexture.java
@@ -114,6 +114,7 @@ public class AnimatedGIFTexture extends ASingleTexture {
 		long now = SystemClock.uptimeMillis();
 		int relTime = (int)((now - mStartTime) % mMovie.duration());
 		mMovie.setTime(relTime);
+		mGIFBitmap.eraseColor(Color.TRANSPARENT);
 		mMovie.draw(mCanvas, 0, 0);
 		mBitmap = Bitmap.createScaledBitmap(mGIFBitmap, mTextureSize, mTextureSize, false);
 		TextureManager.getInstance().replaceTexture(this);


### PR DESCRIPTION
 Clears before drawing the canvas to support transparent GIFs.