### PR TITLE
Fixes semantic issues with a couple of methods.

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -368,7 +368,7 @@ public abstract class ATransformable3D implements IGraphNodeMember {
      * @return A reference to this {@link ATransformable3D} to facilitate chaining.
      */
     public ATransformable3D setRotation(final Vector3 axis, double angle) {
-        mOrientation.multiply(mTmpOrientation.fromAngleAxis(axis, angle));
+        mOrientation.fromAngleAxis(axis, angle);
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;
@@ -385,7 +385,7 @@ public abstract class ATransformable3D implements IGraphNodeMember {
      * @return A reference to this {@link ATransformable3D} to facilitate chaining.
      */
     public ATransformable3D setRotation(final Vector3.Axis axis, double angle) {
-        mOrientation.multiply(mTmpOrientation.fromAngleAxis(axis, angle));
+        mOrientation.fromAngleAxis(axis, angle);
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;
@@ -404,7 +404,7 @@ public abstract class ATransformable3D implements IGraphNodeMember {
      * @return A reference to this {@link ATransformable3D} to facilitate chaining.
      */
     public ATransformable3D setRotation(double x, double y, double z, double angle) {
-        mOrientation.multiply(mTmpOrientation.fromAngleAxis(x, y, z, angle));
+        mOrientation.fromAngleAxis(x, y, z, angle);
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;
@@ -420,7 +420,7 @@ public abstract class ATransformable3D implements IGraphNodeMember {
      * @return A reference to this {@link ATransformable3D} to facilitate chaining.
      */
     public ATransformable3D setRotation(final Matrix4 matrix) {
-        mOrientation.multiply(mTmpOrientation.fromMatrix(matrix));
+        mOrientation.fromMatrix(matrix);
         mLookAtValid = false;
         markModelMatrixDirty();
         return this;

--- a/rajawali/src/main/java/org/rajawali3d/math/vector/Vector3.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/vector/Vector3.java
@@ -578,14 +578,14 @@ public class Vector3 {
      * @return double The initial magnitude.
      */
     public double normalize() {
-        double mod = Math.sqrt(x * x + y * y + z * z);
-        if (mod != 0 && mod != 1) {
-            mod = 1 / mod;
+        double mag = Math.sqrt(x * x + y * y + z * z);
+        if (mag != 0 && mag != 1) {
+            double mod = 1 / mag;
             x *= mod;
             y *= mod;
             z *= mod;
         }
-        return mod;
+        return mag;
     }
 
     /**
@@ -1231,6 +1231,37 @@ public class Vector3 {
      */
     public boolean equals(final Vector3 obj, double error) {
         return (Math.abs(obj.x - x) <= error) && (Math.abs(obj.y - y) <= error) && (Math.abs(obj.y - y) <= error);
+    }
+
+    /**
+     * Fills x, y, z values into first three positions in the
+     * supplied array, if it is large enough to accommodate
+     * them.
+     * 
+     * @param array The array to be populated
+     * 
+     * @return The passed array with the xyz values inserted
+     */
+    public double[] toArray(double[] array)
+    {
+    	if(array != null && array.length >= 3)
+    	{
+    		array[0] = x;
+    		array[1] = y;
+    		array[2] = z;
+    	}
+
+    	return array;
+    }
+
+    /**
+     * Returns an array representation of this Vector3.
+     * 
+     * @return An array containing this Vector3's xyz values.
+     */
+    public double[] toArray()
+    {
+    	return toArray(new double[3]);
     }
 
     /*


### PR DESCRIPTION
Vector3.normalize's contract stipulates that it will return the original magnitude of the vector; currently it returns the reciprocal of the magnitude. Similarly, the setRotation methods in ATransformable should set the absolute value of mOrientation from the supplied arguments, but currently apply the rotation to the existing orientation and are therefore indistinguishable from the rotate() methods.