### PR TITLE
Pick a suitable config (8888) when background is transparent

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/surface/RajawaliSurfaceView.java
+++ b/rajawali/src/main/java/org/rajawali3d/surface/RajawaliSurfaceView.java
@@ -79,13 +79,16 @@ public class RajawaliSurfaceView extends GLSurfaceView implements IRajawaliSurfa
         final int glesMajorVersion = Capabilities.getGLESMajorVersion();
         setEGLContextClientVersion(glesMajorVersion);
 
-        setEGLConfigChooser(new RajawaliEGLConfigChooser(glesMajorVersion, mAntiAliasingConfig, mMultiSampleCount,
-            mBitsRed, mBitsGreen, mBitsBlue, mBitsAlpha, mBitsDepth));
-
         if (mIsTransparent) {
+            setEGLConfigChooser(new RajawaliEGLConfigChooser(glesMajorVersion, mAntiAliasingConfig, mMultiSampleCount,
+                    8, 8, 8, 8, mBitsDepth));
+
             getHolder().setFormat(PixelFormat.TRANSLUCENT);
             setZOrderOnTop(true);
         } else {
+            setEGLConfigChooser(new RajawaliEGLConfigChooser(glesMajorVersion, mAntiAliasingConfig, mMultiSampleCount,
+                    mBitsRed, mBitsGreen, mBitsBlue, mBitsAlpha, mBitsDepth));
+
             getHolder().setFormat(PixelFormat.RGBA_8888);
             setZOrderOnTop(false);
         }


### PR DESCRIPTION
RajawaliSurfaceView was initialized with 0 bits for mBitsAlpha and there was no way to alter that value programatically. Not every combination of RGB and A sizes works. So, I force 8888 when mIsTransparent.