### PR TITLE
Remove redundant code?

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -840,9 +840,6 @@ public class Material {
         for (int i = 0; i < num; i++) {
             ATexture texture = mTextureList.get(i);
             bindTextureByName(texture.getTextureName(), i, texture);
-            GLES20.glActiveTexture(GLES20.GL_TEXTURE0 + i);
-            GLES20.glBindTexture(texture.getGLTextureType(), texture.getTextureId());
-            GLES20.glUniform1i(GLES20.glGetUniformLocation(mProgramHandle, texture.getTextureName()), i);
         }
 
         if (mPlugins != null)


### PR DESCRIPTION
This is a very minor PR, just trying to point out what I think is a small mistake?
Note that I am very very far from an expert but my common sense reading this code makes me feel the texture attachment GL calls are done twice. (once in the code block I removed and then again in the ```bindTextureByName``` method above)
If that duplication was intentional please disregard this PR.