### PR TITLE
Fixes #1588

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/materials/MaterialsFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/materials/MaterialsFragment.java
@@ -30,7 +30,7 @@ public class MaterialsFragment extends AExampleFragment {
 
         @Override
 		protected void initScene() {
-			mLight = new DirectionalLight(.3f, -.3f, -1);
+			mLight = new DirectionalLight(.3f, -.3f, 1);
 			mLight.setPower(.6f);
 
 			getCurrentScene().addLight(mLight);

--- a/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/RenderToTextureFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/RenderToTextureFragment.java
@@ -13,7 +13,7 @@ import org.rajawali3d.math.vector.Vector3;
 import org.rajawali3d.postprocessing.PostProcessingManager;
 import org.rajawali3d.postprocessing.passes.RenderPass;
 import org.rajawali3d.primitives.Cube;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 import java.util.Random;
 
@@ -26,9 +26,9 @@ public class RenderToTextureFragment extends AExampleFragment {
 
 	private final class RenderToTextureRenderer extends AExampleRenderer {
 		private PostProcessingManager mEffects;
-		private RajawaliScene mOtherScene;
-		private Object3D mSphere;
-		private ATexture mCurrentTexture;
+		private Scene                 mOtherScene;
+		private Object3D              mSphere;
+		private ATexture              mCurrentTexture;
 
 		public RenderToTextureRenderer(Context context) {
 			super(context);
@@ -83,7 +83,7 @@ public class RenderToTextureFragment extends AExampleFragment {
 			//    that uses the rendered to texture
 			//
 
-			mOtherScene = new RajawaliScene(this);
+			mOtherScene = new Scene(this);
 			mOtherScene.setBackgroundColor(0xffffff);
 			mOtherScene.addLight(light);
 

--- a/rajawali/src/main/java/org/rajawali3d/animation/AnimationGroup.java
+++ b/rajawali/src/main/java/org/rajawali3d/animation/AnimationGroup.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.rajawali3d.animation;
 
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,10 +20,10 @@ import java.util.List;
 /**
  * A group of {@link Animation}s that will all be played and paused at the same time. When using a group, use
  * {@link AnimationGroup#addAnimation(Animation)} to add each desired animation to the group and register the group to the scene
- * with {@link RajawaliScene#registerAnimation(Animation)}. When ready, call {@link #play()} to begin all animations.
- * 
+ * with {@link Scene#registerAnimation(Animation)}. When ready, call {@link #play()} to begin all animations.
+ *
  * @author Ian Thomas (toxicbakery@gmail.com)
- * 
+ *
  */
 public class AnimationGroup extends Animation {
 
@@ -37,7 +37,7 @@ public class AnimationGroup extends Animation {
 	public void update(double deltaTime) {
 		if (!isPlaying())
 			return;
-		
+
 		// Update the animations and determine if any animations are still playing
 		boolean stillPlaying = false;
 		for (int i = 0, j = mAnimations.size(); i < j; ++i) {
@@ -47,9 +47,9 @@ public class AnimationGroup extends Animation {
 			if (!stillPlaying && anim.isPlaying())
 				stillPlaying = true;
 		}
-		
+
 		// If no more animations are playing, mark the group has ended
-		if (!stillPlaying) 
+		if (!stillPlaying)
 			setState(State.ENDED);
 
 		if (isEnded()) {
@@ -94,7 +94,7 @@ public class AnimationGroup extends Animation {
 				throw new UnsupportedOperationException(mRepeatMode.toString());
 			}
 		}
-		
+
 	}
 
 	@Override
@@ -132,7 +132,7 @@ public class AnimationGroup extends Animation {
 	public void addAnimation(Animation animation) {
 		mAnimations.add(animation);
 	}
-	
+
 	protected void reverseAll() {
 		mIsReversing = !mIsReversing;
 		for (int i = 0, j = mAnimations.size(); i < j; ++i) {

--- a/rajawali/src/main/java/org/rajawali3d/loader/LoaderAWD.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/LoaderAWD.java
@@ -39,7 +39,7 @@ import org.rajawali3d.math.Matrix4;
 import org.rajawali3d.math.Quaternion;
 import org.rajawali3d.math.vector.Vector3;
 import org.rajawali3d.renderer.Renderer;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 import org.rajawali3d.util.LittleEndianDataInputStream;
 import org.rajawali3d.util.RajLog;
 
@@ -375,7 +375,7 @@ public class LoaderAWD extends AMeshLoader {
     /**
      * This is called when all blocks have finished parsing. This is the time to modify any block
      * data as needed from the passed list before conversion to {@link BaseObject3D} or {@link
-     * RajawaliScene} occurs.
+     * Scene} occurs.
      */
     public void onBlockParsingFinished(List<IBlockParser> blockParsers) {
         Object3D temp;

--- a/rajawali/src/main/java/org/rajawali3d/loader/async/IAsyncLoaderCallback.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/async/IAsyncLoaderCallback.java
@@ -1,11 +1,11 @@
 package org.rajawali3d.loader.async;
 
 import org.rajawali3d.loader.ALoader;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * Interface for defining a asynchronous loader callback. This will be provided
- * to the {@link RajawaliScene#loadModel(ALoader, IAsyncLoaderCallback, int)} and
+ * to the {@link Scene#loadModel(ALoader, IAsyncLoaderCallback, int)} and
  * related calls.
  *
  * @author Jared Woolston (jwoolston@idealcorp.com)

--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -41,7 +41,9 @@ import org.rajawali3d.materials.textures.CubeMapTexture;
 import org.rajawali3d.materials.textures.SphereMapTexture;
 import org.rajawali3d.materials.textures.TextureManager;
 import org.rajawali3d.math.Matrix4;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.renderer.Renderer;
+import org.rajawali3d.scene.Scene;
+import org.rajawali3d.util.Capabilities;
 import org.rajawali3d.util.RajLog;
 
 import java.util.ArrayList;
@@ -74,9 +76,7 @@ public class Material {
      */
     public static enum PluginInsertLocation {
         PRE_LIGHTING, PRE_DIFFUSE, PRE_SPECULAR, PRE_ALPHA, PRE_TRANSFORM, POST_TRANSFORM, IGNORE
-    }
-
-    ;
+    };
 
     private final boolean mCapabilitiesCheckDeferred;
 
@@ -121,7 +121,7 @@ public class Material {
     private boolean mUseVertexColors;
     /**
      * Indicates whether lighting should be used or not. This must be set to true when using a
-     * {@link DiffuseMethod} or a {@link SpecularMethod}. Lights are added to a scene {@link RajawaliScene}
+     * {@link DiffuseMethod} or a {@link SpecularMethod}. Lights are added to a scene {@link Scene}
      * and are automatically added to the material.
      */
     private boolean mLightingEnabled;
@@ -207,7 +207,7 @@ public class Material {
     private float mTime;
     /**
      * The lights that affect the material. Lights shouldn't be managed by any other class
-     * than {@link RajawaliScene}. To add lights to a scene call {@link RajawaliScene#addLight(ALight).
+     * than {@link Scene}. To add lights to a scene call {@link Scene#addLight(ALight).
      */
     protected List<ALight> mLights;
     /**
@@ -822,7 +822,7 @@ public class Material {
 
     /**
      * Binds the textures to an OpenGL texturing target. Called every frame by
-     * {@link RajawaliScene#render(long, double, org.rajawali3d.renderer.RenderTarget)}. Shouldn't
+     * {@link Scene#render(long, double, org.rajawali3d.renderer.RenderTarget)}. Shouldn't
      * be called manually.
      */
     public void bindTextures() {
@@ -978,7 +978,7 @@ public class Material {
     }
 
     /**
-     * Set the vertex color buffer handle. This is passed to {@link VertexShader#setColorBuffer(int)}
+     * Set the vertex color buffer handle. This is passed to {@link VertexShader#setVertexColors(int)}
      *
      * @param vertexColorBufferHandle
      */
@@ -987,7 +987,7 @@ public class Material {
     }
 
     /**
-     * Set the vertex color buffer handle. This is passed to {@link VertexShader#setColorBuffer(int)}
+     * Set the vertex color buffer handle. This is passed to {@link VertexShader#setVertexColors(int)}
      *
      * @param bufferInfo
      */
@@ -1051,7 +1051,7 @@ public class Material {
 
     /**
      * Indicates whether lighting should be used or not. This must be set to true when using a
-     * {@link DiffuseMethod} or a {@link SpecularMethod}. Lights are added to a scene {@link RajawaliScene}
+     * {@link DiffuseMethod} or a {@link SpecularMethod}. Lights are added to a scene {@link Scene}
      * and are automatically added to the material.
      *
      * @param value
@@ -1062,7 +1062,7 @@ public class Material {
 
     /**
      * Indicates whether lighting should be used or not. This must be set to true when using a
-     * {@link DiffuseMethod} or a {@link SpecularMethod}. Lights are added to a scene {@link RajawaliScene}
+     * {@link DiffuseMethod} or a {@link SpecularMethod}. Lights are added to a scene {@link Scene}
      * and are automatically added to the material.
      *
      * @return
@@ -1153,7 +1153,7 @@ public class Material {
 
     /**
      * The lights that affect the material. Lights shouldn't be managed by any other class
-     * than {@link RajawaliScene}. To add lights to a scene call {@link RajawaliScene#addLight(ALight).
+     * than {@link Scene}. To add lights to a scene call {@link Scene#addLight(ALight).
      *
      * @param lights The lights collection
      */

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -31,22 +31,22 @@ import java.util.Set;
  * that lets you write shaders in Java. The main reason for this is maintainability and code
  * reuse. The lack of operator overloading makes this slightly verbose however. Instead of
  * writing this in GLSL:
- * 
+ *
  * <pre><code>
  * myVar *= myOtherVar;
  * </code></pre>
- * 
+ *
  * You'll have to write this:
- * 
+ *
  * <pre><code>
  * myVar.assignAdd(myOtherVar);
  * </code></pre>
- * 
+ *
  * GLSL data types are wrapped into their own classes. Because most of the data type names are
  * reserved keywords in Java they are prefixed with 'R'.<br>
  * For instance:
- * 
- * </p> 
+ *
+ * </p>
  * <ul>
  * 	<li>float: {@link RFloat}</li>
  * 	<li>vec2: {@link RVec2}</li>
@@ -54,10 +54,10 @@ import java.util.Set;
  * 	<li>mat3: {@link RMat3}</li>
  * 	<li>sampler2D: {@link RSampler2D}</li>
  * </ul>
- * 
+ *
  * Shader initialization should be done in the {@link AShader#initialize()} method. This is
  * the place where you would create your uniforms, varyings, constanst, etc:
- * 
+ *
  * <pre><code>
  * @Override
  * public void initialize()
@@ -70,10 +70,10 @@ import java.util.Set;
  * 		mcMyIntConstant 		= (RInt) addConstant("cMyIntConstant", DataType.INT);
  * }
  * </code></pre>
- * 
+ *
  * All attributes and uniforms needs to get their handles. This is an integer that represents
- * the location of a specific attribute or uniform within a shader program. 
- * 
+ * the location of a specific attribute or uniform within a shader program.
+ *
  * <pre><code>
  * @Override
  * public void setLocations(int programHandle) {
@@ -81,9 +81,9 @@ import java.util.Set;
  * 		maMyVec2AttributeHandle	= getAttributeLocation(programHandle, "uMyVec2Attribute");
  * }
  * </code></pre>
- * 
+ *
  * This handle is subsequently used in {@link AShader#applyParams())} to set the attribute/uniform value:
- * 
+ *
  * <pre><code>
  * @Override
  * public void applyParams() {
@@ -91,9 +91,9 @@ import java.util.Set;
  * 		GLES20.glUniform3fv(muMyVec3UniformHandle, 1, myFloatArrayValue, 0);
  * }
  * </code></pre>
- * 
+ *
  * The shader code that goes into main() in a regular shader goes into {@link AShader#main()}:
- * 
+ *
  * <pre><code>
  * @Override
  * public void main() {
@@ -105,27 +105,27 @@ import java.util.Set;
  * 	// etc ..
  * }
  * </code></pre>
- * 
+ *
  * @author dennis.ippel
  *
  */
 public abstract class AShader extends AShaderBase {
 	public static String SHADER_ID;
-	
+
 	public static enum ShaderType {
 		VERTEX, FRAGMENT, VERTEX_SHADER_FRAGMENT, FRAGMENT_SHADER_FRAGMENT
 	}
-	
+
 	public static enum Operator {
 		LESS_THAN("<"), LESS_THAN_EQUALS("<="), GREATER_THAN(">"), GREATER_THAN_EQUALS(">="),
 		EQUALS("=="), NOT_EQUALS("!="), AND("&&"), OR("||"), XOR("^^");
-		
+
 		private String mOperatorString;
-		
+
 		Operator(String operatorString) {
 			mOperatorString = operatorString;
 		}
-		
+
 		public String getOperatorString() {
 			return mOperatorString;
 		}
@@ -142,19 +142,19 @@ public abstract class AShader extends AShaderBase {
 	 */
 	protected final GLFragColor GL_FRAG_COLOR = new GLFragColor();
 	/**
-	 * Contains the window-relative coordinates of the current fragment 
+	 * Contains the window-relative coordinates of the current fragment
 	 */
 	protected final GLFragCoord GL_FRAG_COORD = new GLFragCoord();
 	/**
-	 * Specifies depth range in window coordinates. If an implementation does 
+	 * Specifies depth range in window coordinates. If an implementation does
 	 * not support highp precision in the fragment language, and state is listed as
 	 * highp, then that state will only be available as mediump in the fragment
 	 * language.
 	 */
 	protected final GLDepthRange GL_DEPTH_RANGE = new GLDepthRange();
-	
+
 	protected String mShaderString;
-	
+
 	private ShaderType mShaderType;
 	private List<String> mPreprocessorDirectives;
 	private Hashtable<String, ShaderVar> mUniforms;
@@ -166,17 +166,17 @@ public abstract class AShader extends AShaderBase {
 	protected List<IShaderFragment> mShaderFragments;
 	protected int mProgramHandle;
 	protected boolean mNeedsBuild = true;
-	
+
 	public AShader() {}
-	
+
 	public AShader(ShaderType shaderType) {
 		mShaderType = shaderType;
 	}
-	
+
 	public AShader(ShaderType shaderType, int resourceId) {
 		this(shaderType, RawShaderLoader.fetch(resourceId));
 	}
-	
+
 	public AShader(ShaderType shaderType, String shaderString) {
 		mShaderType = shaderType;
 		mShaderString = shaderString;
@@ -197,7 +197,7 @@ public abstract class AShader extends AShaderBase {
 
 	/**
 	 * Add a preprocessor directive like #define, #extension, #version etc.
-	 * 
+	 *
 	 * @param directive
 	 */
 	public void addPreprocessorDirective(String directive)
@@ -206,17 +206,17 @@ public abstract class AShader extends AShaderBase {
 			mPreprocessorDirectives = new ArrayList<String>();
 		mPreprocessorDirectives.add(directive);
 	}
-	
+
 	/**
 	 * Add a precision qualifier. There are three precision qualifiers: highp​, mediump​, and lowp​.
-	 * They have no semantic meaning or functional effect. They can apply to any floating-point type 
-	 * (vector or matrix), or any integer type. All variables of a certain type can be declared to 
+	 * They have no semantic meaning or functional effect. They can apply to any floating-point type
+	 * (vector or matrix), or any integer type. All variables of a certain type can be declared to
 	 * have a precision by using the precision​ statement. It's syntax is as follows:
 	 * <p>precision precision-qualifier​ type​;</p>
-	 * In this case, type​ can only be float​ or int​. This will affect all collections of that basic type. 
-	 * So float​ will affect all floating-point scalars, vectors, and matrices. The int​ type will affect 
+	 * In this case, type​ can only be float​ or int​. This will affect all collections of that basic type.
+	 * So float​ will affect all floating-point scalars, vectors, and matrices. The int​ type will affect
 	 * all signed and unsigned integer scalars and vectors.
-	 * 
+	 *
 	 * @param dataType float, int
 	 * @param precision highp, mediump, lowp
 	 */
@@ -229,7 +229,7 @@ public abstract class AShader extends AShaderBase {
 	 * primitive being processed. All uniform variables are read-only and are initialized externally either at link
 	 * time or through the API. The link time initial value is either the value of the variable's initializer, if
 	 * present, or 0 if no initializer is present. Sampler types cannot have initializers.
-	 * 
+	 *
 	 * @param var	A global shader variable.
 	 * @return
 	 */
@@ -237,13 +237,13 @@ public abstract class AShader extends AShaderBase {
 	{
 		return addUniform(var.getVarString(), var.getDataType());
 	}
-	
+
 	/**
 	 * Add a uniform. The uniform qualifier is used to declare global variables whose values are the same across the entire
 	 * primitive being processed. All uniform variables are read-only and are initialized externally either at link
 	 * time or through the API. The link time initial value is either the value of the variable's initializer, if
 	 * present, or 0 if no initializer is present. Sampler types cannot have initializers.
-	 * 
+	 *
 	 * @param var	A global shader variable
 	 * @param index	The index for the shader variable. This number will appear suffixed in the final shader string.
 	 * @return
@@ -252,13 +252,13 @@ public abstract class AShader extends AShaderBase {
 	{
 		return addUniform(var.getVarString() + Integer.toString(index), var.getDataType());
 	}
-	
+
 	/**
 	 * Add a uniform. The uniform qualifier is used to declare global variables whose values are the same across the entire
 	 * primitive being processed. All uniform variables are read-only and are initialized externally either at link
 	 * time or through the API. The link time initial value is either the value of the variable's initializer, if
 	 * present, or 0 if no initializer is present. Sampler types cannot have initializers.
-	 * 
+	 *
 	 * @param var		A global shader variable
 	 * @param suffix	A string that will appear suffixed in the final shader string.
 	 * @return
@@ -267,13 +267,13 @@ public abstract class AShader extends AShaderBase {
 	{
 		return addUniform(var.getVarString() + suffix, var.getDataType());
 	}
-	
+
 	/**
 	 * Add a uniform. The uniform qualifier is used to declare global variables whose values are the same across the entire
 	 * primitive being processed. All uniform variables are read-only and are initialized externally either at link
 	 * time or through the API. The link time initial value is either the value of the variable's initializer, if
 	 * present, or 0 if no initializer is present. Sampler types cannot have initializers.
-	 * 
+	 *
 	 * @param name		The uniform name
 	 * @param dataType	The uniform data type
 	 * @return
@@ -285,41 +285,41 @@ public abstract class AShader extends AShaderBase {
 		mUniforms.put(v.getName(), v);
 		return v;
 	}
-	
+
 	public void setUniform1f(String name, float value)
 	{
 		int handle = getUniformLocation(mProgramHandle, name);
 		GLES20.glUniform1f(handle, value);
 	}
-	
+
 	public void setUniform2fv(String name, float[] value)
 	{
 		int handle = getUniformLocation(mProgramHandle, name);
 		GLES20.glUniform2fv(handle, 1, value, 0);
 	}
-	
+
 	public void setUniform3fv(String name, float[] value)
 	{
 		int handle = getUniformLocation(mProgramHandle, name);
 		GLES20.glUniform3fv(handle, 1, value, 0);
 	}
-	
+
 	public void setUniform1i(String name, int value)
 	{
 		int handle = getUniformLocation(mProgramHandle, name);
 		GLES20.glUniform1i(handle, value);
 	}
-	
+
 	/**
 	 * Returns all uniforms
-	 * 
+	 *
 	 * @return
 	 */
 	public Hashtable<String, ShaderVar> getUniforms()
 	{
 		return mUniforms;
 	}
-	
+
 	/**
 	 * The attribute qualifier is used to declare variables that are passed to a vertex shader from OpenGL on a
 	 * per-vertex basis. It is an error to declare an attribute variable in any type of shader other than a vertex
@@ -328,7 +328,7 @@ public abstract class AShader extends AShaderBase {
 	 * convey vertex attributes to the vertex shader and are expected to change on every vertex shader run. The
 	 * attribute qualifier can be used only with float, floating-point vectors, and matrices. Attribute variables
 	 * cannot be declared as arrays or structures.
-	 * 
+	 *
 	 * @param var	A global shader variable
 	 * @return
 	 */
@@ -336,7 +336,7 @@ public abstract class AShader extends AShaderBase {
 	{
 		return addAttribute(var.getVarString(), var.getDataType());
 	}
-	
+
 	/**
 	 * The attribute qualifier is used to declare variables that are passed to a vertex shader from OpenGL on a
 	 * per-vertex basis. It is an error to declare an attribute variable in any type of shader other than a vertex
@@ -345,7 +345,7 @@ public abstract class AShader extends AShaderBase {
 	 * convey vertex attributes to the vertex shader and are expected to change on every vertex shader run. The
 	 * attribute qualifier can be used only with float, floating-point vectors, and matrices. Attribute variables
 	 * cannot be declared as arrays or structures.
-	 * 
+	 *
 	 * @param name		The attribute name
 	 * @param dataType	The attribute data type
 	 * @return
@@ -356,7 +356,7 @@ public abstract class AShader extends AShaderBase {
 		mAttributes.put(v.getName(), v);
 		return v;
 	}
-	
+
 	/**
 	 * Returns all attributes
 	 * @return
@@ -372,21 +372,21 @@ public abstract class AShader extends AShaderBase {
 	 * coordinates, etc.) and write them to variables declared with the varying qualifier. A vertex shader may
 	 * also read varying variables, getting back the same values it has written. Reading a varying variable in a
 	 * vertex shader returns undefined values if it is read before being written.
-	 * 
+	 *
 	 * @param var
 	 * @return
 	 */
 	protected ShaderVar addVarying(IGlobalShaderVar var) {
 		return addVarying(var.getVarString(), var.getDataType());
 	}
-	
+
 	/**
 	 * Varying variables provide the interface between the vertex shaders, the fragment shaders, and the fixed
 	 * functionality between them. Vertex shaders will compute values per vertex (such as color, texture
 	 * coordinates, etc.) and write them to variables declared with the varying qualifier. A vertex shader may
 	 * also read varying variables, getting back the same values it has written. Reading a varying variable in a
 	 * vertex shader returns undefined values if it is read before being written.
-	 * 
+	 *
 	 * @param var	A global shader variable
 	 * @param index	The index for the shader variable. This number will appear suffixed in the final shader string.
 	 * @return
@@ -395,14 +395,14 @@ public abstract class AShader extends AShaderBase {
 	{
 		return addVarying(var.getVarString() + Integer.toString(index), var.getDataType());
 	}
-	
+
 	/**
 	 * Varying variables provide the interface between the vertex shaders, the fragment shaders, and the fixed
 	 * functionality between them. Vertex shaders will compute values per vertex (such as color, texture
 	 * coordinates, etc.) and write them to variables declared with the varying qualifier. A vertex shader may
 	 * also read varying variables, getting back the same values it has written. Reading a varying variable in a
 	 * vertex shader returns undefined values if it is read before being written.
-	 * 
+	 *
 	 * @param name		The varying name
 	 * @param dataType	The varying data type
 	 * @return
@@ -413,10 +413,10 @@ public abstract class AShader extends AShaderBase {
 		mVaryings.put(v.getName(), v);
 		return v;
 	}
-	
+
 	/**
 	 * Returns all varyings
-	 * 
+	 *
 	 * @return
 	 */
 	public Hashtable<String, ShaderVar> getVaryings()
@@ -426,17 +426,17 @@ public abstract class AShader extends AShaderBase {
 
 	/**
 	 * Adds a global variable
-	 * 
+	 *
 	 * @param var	A global shader variable
 	 * @return
 	 */
 	protected ShaderVar addGlobal(IGlobalShaderVar var) {
 		return addGlobal(var.getVarString(), var.getDataType());
 	}
-	
+
 	/**
 	 * Adds a global variable
-	 * 
+	 *
 	 * @param var	A global shader variable
 	 * @param index	The index for the shader variable. This number will appear suffixed in the final shader string.
 	 * @return
@@ -444,10 +444,10 @@ public abstract class AShader extends AShaderBase {
 	protected ShaderVar addGlobal(IGlobalShaderVar var, int index) {
 		return addGlobal(var.getVarString() + Integer.toString(index), var.getDataType());
 	}
-	
+
 	/**
 	 * Adds a global variable
-	 * 
+	 *
 	 * @param name		The global name
 	 * @param dataType	The global data type
 	 * @return
@@ -458,20 +458,20 @@ public abstract class AShader extends AShaderBase {
 		mGlobals.put(v.getName(), v);
 		return v;
 	}
-	
+
 	/**
 	 * Returns all globals
-	 * 
+	 *
 	 * @return
 	 */
 	public Hashtable<String, ShaderVar> getGlobals()
 	{
 		return mGlobals;
 	}
-	
+
 	/**
 	 * Returns a global. This can be a regular global but also a uniform, attribute, const or varying.
-	 * 
+	 *
 	 * @param var
 	 * @return
 	 */
@@ -481,10 +481,10 @@ public abstract class AShader extends AShaderBase {
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	/**
 	 * Returns a global. This can be a regular global but also a uniform, attribute, const or varying.
-	 * 
+	 *
 	 * @param var
 	 * @param index
 	 * @return
@@ -495,10 +495,10 @@ public abstract class AShader extends AShaderBase {
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	/**
 	 * Add a constant
-	 * 
+	 *
 	 * @param name
 	 * @param value
 	 * @return
@@ -509,7 +509,7 @@ public abstract class AShader extends AShaderBase {
 
 	/**
 	 * Add a constant
-	 * 
+	 *
 	 * @param name
 	 * @param value
 	 * @return
@@ -520,7 +520,7 @@ public abstract class AShader extends AShaderBase {
 
 	/**
 	 * Add a constant
-	 * 
+	 *
 	 * @param name
 	 * @param value
 	 * @return
@@ -531,7 +531,7 @@ public abstract class AShader extends AShaderBase {
 
 	/**
 	 * Add a constant
-	 * 
+	 *
 	 * @param name
 	 * @param var
 	 * @return
@@ -543,17 +543,17 @@ public abstract class AShader extends AShaderBase {
 		mConstants.put(v.getName(), v);
 		return v;
 	}
-	
+
 	/**
 	 * Returns all constants
-	 * 
+	 *
 	 * @return
 	 */
 	public Hashtable<String, ShaderVar> getConsts()
 	{
 		return mConstants;
 	}
-	
+
 	public void setLocations(final int programHandle)
 	{
 		mProgramHandle = programHandle;
@@ -565,52 +565,52 @@ public abstract class AShader extends AShaderBase {
 	protected int getUniformLocation(int programHandle, IGlobalShaderVar var) {
 		return getUniformLocation(programHandle, var.getVarString());
 	}
-	
+
 	protected int getUniformLocation(int programHandle, IGlobalShaderVar var, int index) {
 		return getUniformLocation(programHandle, var.getVarString() + Integer.toString(index));
 	}
-	
+
 	protected int getUniformLocation(int programHandle, IGlobalShaderVar var, String suffix) {
 		return getUniformLocation(programHandle, var.getVarString() + suffix);
 	}
-	
+
 	protected int getUniformLocation(int programHandle, String name) {
 		int result = GLES20.glGetUniformLocation(programHandle, name);
-        if (result < 0) RajLog.e("Getting location of uniform: " + name + " returned -1!");
+        if (result < 0 && RajLog.isDebugEnabled()) RajLog.e("Getting location of uniform: " + name + " returned -1!");
 		return result;
 	}
 
 	protected int getAttribLocation(int programHandle, IGlobalShaderVar var) {
 		return getAttribLocation(programHandle, var.getVarString());
 	}
-	
+
 	protected int getAttribLocation(int programHandle, IGlobalShaderVar var, int index) {
 		return getAttribLocation(programHandle, var.getVarString() + Integer.toString(index));
 	}
-	
+
 	protected int getAttribLocation(int programHandle, String name) {
 		int result = GLES20.glGetAttribLocation(programHandle, name);
 		return result;
 	}
-	
+
 	public void addShaderFragment(IShaderFragment fragment)
 	{
 		if(fragment == null) return;
 		mShaderFragments.add(fragment);
 	}
-	
+
 	public IShaderFragment getShaderFragment(String shaderId) {
 		for(IShaderFragment frag : mShaderFragments)
 			if(frag.getShaderId().equals(shaderId))
 				return frag;
-		
+
 		return null;
 	}
 
 	public ShaderType getShaderType() {
 		return mShaderType;
 	}
-	
+
 	public void setStringBuilder(StringBuilder stringBuilder)
 	{
 		mShaderSB = stringBuilder;
@@ -634,7 +634,7 @@ public abstract class AShader extends AShaderBase {
 				s.append(directive).append("\n");
 			}
 		}
-		
+
 		//
 		// -- Precision statements
 		//
@@ -655,48 +655,48 @@ public abstract class AShader extends AShaderBase {
 		//
 
 		Hashtable<String, ShaderVar> consts = new Hashtable<String, ShaderVar>(mConstants);
-		
+
 		for(int i=0; i<mShaderFragments.size(); i++)
 		{
 			IShaderFragment fragment = mShaderFragments.get(i);
 			if(fragment.getConsts() != null)
 				consts.putAll(fragment.getConsts());
 		}
-		
+
 		Set<Entry<String, ShaderVar>> set = consts.entrySet();
 		Iterator<Entry<String, ShaderVar>> iter = set.iterator();
 		while (iter.hasNext()) {
 			Entry<String, ShaderVar> e = iter.next();
 			ShaderVar var = e.getValue();
-			
+
 			String arrayStr = var.isArray() ? "[" +var.getArraySize()+ "]" : "";
-			
+
 			s.append("const ").append(var.mDataType.getTypeString())
 					.append(" ").append(var.mName).append(arrayStr)
 					.append(" = ").append(var.getValue()).append(";\n");
 		}
-		
+
 		//
 		// -- Uniforms
 		//
 
 		Hashtable<String, ShaderVar> uniforms = new Hashtable<String, ShaderVar>(mUniforms);
-		
+
 		for(int i=0; i<mShaderFragments.size(); i++)
 		{
 			IShaderFragment fragment = mShaderFragments.get(i);
 			if(fragment.getUniforms() != null)
 				uniforms.putAll(fragment.getUniforms());
 		}
-		
+
 		set = uniforms.entrySet();
 		iter = set.iterator();
 		while (iter.hasNext()) {
 			Entry<String, ShaderVar> e = iter.next();
 			ShaderVar var = e.getValue();
-			
+
 			String arrayStr = var.isArray() ? "[" +var.getArraySize()+ "]" : "";
-			
+
 			s.append("uniform ").append(var.mDataType.getTypeString())
 					.append(" ").append(var.mName).append(arrayStr).append(";\n");
 		}
@@ -704,9 +704,9 @@ public abstract class AShader extends AShaderBase {
 		//
 		// -- Attributes
 		//
-		
+
 		Hashtable<String, ShaderVar> attributes = new Hashtable<String, ShaderVar>(mAttributes);
-		
+
 		for(int i=0; i<mShaderFragments.size(); i++)
 		{
 			IShaderFragment fragment = mShaderFragments.get(i);
@@ -729,14 +729,14 @@ public abstract class AShader extends AShaderBase {
 		//
 
 		Hashtable<String, ShaderVar> varyings = new Hashtable<String, ShaderVar>(mVaryings);
-		
+
 		for(int i=0; i<mShaderFragments.size(); i++)
 		{
 			IShaderFragment fragment = mShaderFragments.get(i);
 			if(fragment.getVaryings() != null)
 				varyings.putAll(fragment.getVaryings());
 		}
-		
+
 		set = varyings.entrySet();
 		iter = set.iterator();
 
@@ -753,14 +753,14 @@ public abstract class AShader extends AShaderBase {
 		//
 
 		Hashtable<String, ShaderVar> globals = new Hashtable<String, ShaderVar>(mGlobals);
-		
+
 		for(int i=0; i<mShaderFragments.size(); i++)
 		{
 			IShaderFragment fragment = mShaderFragments.get(i);
 			if(fragment.getGlobals() != null)
 				globals.putAll(fragment.getGlobals());
 		}
-		
+
 		set = globals.entrySet();
 		iter = set.iterator();
 
@@ -771,35 +771,35 @@ public abstract class AShader extends AShaderBase {
 			s.append(var.mDataType.getTypeString())
 					.append(" ").append(var.mName).append(arrayStr).append(";\n");
 		}
-		
+
 		//
 		// -- Call main
 		//
-		
+
 		s.append("\nvoid main() {\n");
 		main();
 		s.append("}\n");
-		
+
 		mShaderString = s.toString();
 		s = null;
 	}
-	
+
 	/**
 	 * applyParams() should be called on every frame. The shader parameters
 	 * are set here.
 	 */
-	public void applyParams() 
+	public void applyParams()
 	{
 		if(mShaderFragments != null)
 			for(int i=0; i<mShaderFragments.size(); i++)
 				mShaderFragments.get(i).applyParams();
 	}
-	
+
 	public int getProgramHandle()
 	{
 		return mProgramHandle;
 	}
-	
+
 	public ShaderVar subtract(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar var = getInstanceForDataType(var1.getDataType());
@@ -807,17 +807,17 @@ public abstract class AShader extends AShaderBase {
 		var.mInitialized = true;
 		return var;
 	}
-	
+
 	public ShaderVar subtract(float value1, ShaderVar var2)
 	{
 		return subtract(new RFloat(Float.toString(value1)), var2);
 	}
-	
+
 	public ShaderVar divide(Float value1, ShaderVar var2)
 	{
 		return divide(new RFloat(Float.toString(value1)), var2);
 	}
-	
+
 	public ShaderVar divide(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar var = getInstanceForDataType(var1.getDataType());
@@ -825,7 +825,7 @@ public abstract class AShader extends AShaderBase {
 		var.mInitialized = true;
 		return var;
 	}
-	
+
 	public ShaderVar multiply(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar var = getInstanceForDataType(var1.getDataType());
@@ -833,7 +833,7 @@ public abstract class AShader extends AShaderBase {
 		var.mInitialized = true;
 		return var;
 	}
-	
+
 	public ShaderVar max(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar var = getInstanceForDataType(var1.getDataType());
@@ -841,14 +841,14 @@ public abstract class AShader extends AShaderBase {
 		var.mInitialized = true;
 		return var;
 	}
-	
+
 	public ShaderVar max(ShaderVar var1, float value2)
 	{
 		ShaderVar s = new ShaderVar("max(" + var1.getName() + ", " + Float.toString(value2) + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar min(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar var = getInstanceForDataType(var1.getDataType());
@@ -856,7 +856,7 @@ public abstract class AShader extends AShaderBase {
 		var.mInitialized = true;
 		return var;
 	}
-	
+
 	public ShaderVar min(ShaderVar var1, float value2)
 	{
 		ShaderVar s = new ShaderVar("min(" + var1.getName() + ", " + Float.toString(value2) + ")", DataType.FLOAT);
@@ -868,12 +868,12 @@ public abstract class AShader extends AShaderBase {
 	{
 		return "normalize(" + value + ")";
 	}
-	
+
 	public String normalize(ShaderVar value)
 	{
 		return normalize(value.getName());
 	}
-	
+
 	public ShaderVar sqrt(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("sqrt(" + var.getName() + ")", DataType.FLOAT);
@@ -894,14 +894,14 @@ public abstract class AShader extends AShaderBase {
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar texture2D(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar s = new ShaderVar("texture2D(" + var1.getName() + ", " + var2.getName() + ")", DataType.VEC4);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar texture3D(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar s = new ShaderVar("texture3D(" + var1.getName() + ", " + var2.getName() + ")", DataType.VEC4);
@@ -915,7 +915,7 @@ public abstract class AShader extends AShaderBase {
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public RVec4 texture2DProj(ShaderVar var1, ShaderVar var2)
 	{
 		RVec4 s = new RVec4("texture2DProj(" + var1.getName() + ", " + var2.getName() + ")", DataType.VEC4);
@@ -929,56 +929,56 @@ public abstract class AShader extends AShaderBase {
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar clamp(ShaderVar var, float value1, float value2)
 	{
 		ShaderVar s = new ShaderVar("clamp(" + var.getName() + ", " + Float.toString(value1) + ", " + Float.toString(value2) + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
-	public ShaderVar mix(ShaderVar var1, ShaderVar var2, float value) 
+
+	public ShaderVar mix(ShaderVar var1, ShaderVar var2, float value)
 	{
 		ShaderVar s = new ShaderVar("mix(" + var1.getName() + ", " + var2.getName() + ", " + Float.toString(value) + ")", DataType.VEC3);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar mix(ShaderVar var1, ShaderVar var2, ShaderVar var3)
 	{
 		ShaderVar s = new ShaderVar("mix(" + var1.getName() + ", " + var2.getName() + ", " + var3.getName() + ")", DataType.VEC3);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar dot(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar s = new ShaderVar("dot(" + var1.getName() + ", " + var2.getName() + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar cos(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("cos(" + var.getName() + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar acos(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("acos(" + var.getName() + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar sin(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("sin(" + var.getName() + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar tan(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("tan(" + var.getName() + ")", DataType.FLOAT);
@@ -999,7 +999,7 @@ public abstract class AShader extends AShaderBase {
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar mod(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar s = new ShaderVar("mod(" + var1.getName() + ", " + var2.getName() + ")", var1.getDataType());
@@ -1013,21 +1013,21 @@ public abstract class AShader extends AShaderBase {
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar floor(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("floor(" + var.getName() + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar radians(ShaderVar var)
 	{
 		ShaderVar s = new ShaderVar("radians(" + var.getName() + ")", DataType.FLOAT);
 		s.mInitialized = true;
 		return s;
 	}
-	
+
 	public ShaderVar reflect(ShaderVar var1, ShaderVar var2)
 	{
 		ShaderVar var = getInstanceForDataType(var1.getDataType());
@@ -1035,85 +1035,85 @@ public abstract class AShader extends AShaderBase {
 		var.mInitialized = true;
 		return var;
 	}
-	
+
 	public void discard()
 	{
 		mShaderSB.append("discard;\n");
 	}
-	
+
 	public static class Condition {
 		private ShaderVar mLeftValue;
 		private Operator mOperator;
 		private String mRightValue;
-		private Operator mJoinOperator;		
-		
+		private Operator mJoinOperator;
+
 		public Condition(Operator joinOperator, ShaderVar leftValue, Operator operator, String rightValue) {
 			mJoinOperator = joinOperator;
 			mLeftValue = leftValue;
 			mOperator = operator;
 			mRightValue = rightValue;
 		}
-		
+
 		public Condition(Operator joinOperator, ShaderVar leftValue, Operator operator, ShaderVar rightValue) {
 			this(joinOperator, leftValue, operator, rightValue.getName());
 		}
-		
+
 		public Condition(Operator joinOperator, ShaderVar leftValue, Operator operator, float rightValue) {
 			this(joinOperator, leftValue, operator, Float.toString(rightValue));
 		}
-		
+
 		public Condition(Operator joinOperator, ShaderVar leftValue, Operator operator, boolean rightValue)
 		{
 			this(joinOperator, leftValue, operator, rightValue == true ? "true" : "false");
 		}
-		
+
 		public Condition(ShaderVar leftValue, Operator operator, String rightValue) {
 			this(null, leftValue, operator, rightValue);
 		}
-		
+
 		public Condition(ShaderVar leftValue, Operator operator, ShaderVar rightValue) {
 			this(leftValue, operator, rightValue.getName());
 		}
-		
+
 		public Condition(ShaderVar leftValue, Operator operator, float rightValue)
 		{
 			this(leftValue, operator, Float.toString(rightValue));
 		}
-		
+
 		public Condition(ShaderVar leftValue, Operator operator, boolean rightValue)
 		{
 			this(leftValue, operator, rightValue == true ? "true" : "false");
 		}
-		
+
 		public ShaderVar getLeftValue() {
 			return mLeftValue;
 		}
-		
+
 		public Operator getOperator() {
 			return mOperator;
 		}
-		
+
 		public String getRightValue() {
 			return mRightValue;
 		}
-		
+
 		public Operator getJoinOperator() {
 			return mJoinOperator;
 		}
 	}
-	
+
 	public void startif(Condition... conditions) {
 		mShaderSB.append("if(");
 		for(int i=0; i<conditions.length; i++) {
 			Condition condition = conditions[i];
-			if(i > 0) mShaderSB.append(condition.getJoinOperator().getOperatorString());			
+			if(i > 0) mShaderSB.append(condition.getJoinOperator().getOperatorString());
 			mShaderSB.append(condition.getLeftValue().getVarName());
 			mShaderSB.append(condition.getOperator().getOperatorString());
 			mShaderSB.append(condition.getRightValue());
 		}
 		mShaderSB.append(")\n{\n");
 	}
-	
+
 	public void startif(Condition condition)
 	{
 		mShaderSB.append("if(");
@@ -1122,21 +1122,21 @@ public abstract class AShader extends AShaderBase {
 		mShaderSB.append(condition.getRightValue());
 		mShaderSB.append(")\n{\n");
 	}
-	
+
 	public void ifelseif(Condition... conditions)
 	{
 		mShaderSB.append("} else ");
 		mShaderSB.append("if(");
 		for(int i=0; i<conditions.length; i++) {
 			Condition condition = conditions[i];
-			if(i > 0) mShaderSB.append(condition.getJoinOperator().getOperatorString());			
+			if(i > 0) mShaderSB.append(condition.getJoinOperator().getOperatorString());
 			mShaderSB.append(condition.getLeftValue().getVarName());
 			mShaderSB.append(condition.getOperator().getOperatorString());
 			mShaderSB.append(condition.getRightValue());
 		}
 		mShaderSB.append(")\n{\n");
 	}
-	
+
 	public void ifelseif(Condition condition)
 	{
 		mShaderSB.append("} else ");
@@ -1146,7 +1146,7 @@ public abstract class AShader extends AShaderBase {
 		mShaderSB.append(condition.getRightValue());
 		mShaderSB.append(")\n{\n");
 	}
-	
+
 	public void ifelse()
 	{
 		mShaderSB.append("} else {\n");
@@ -1156,63 +1156,63 @@ public abstract class AShader extends AShaderBase {
 	{
 		mShaderSB.append("}\n");
 	}
-	
+
 	public ShaderVar castInt(float value)
 	{
 		return castInt(Float.toString(value));
 	}
-	
+
 	public ShaderVar castInt(ShaderVar value)
 	{
 		return castInt(value.getVarName());
 	}
-	
+
 	public ShaderVar castInt(String value)
 	{
 		ShaderVar v = new ShaderVar("int(" + value + ")", DataType.INT);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castVec2(float x)
 	{
 		return castVec2(Float.toString(x));
 	}
-	
+
 	public ShaderVar castVec2(float x, float y)
 	{
 		return castVec2(Float.toString(x), Float.toString(y));
 	}
-		
+
 	public ShaderVar castVec2(String x, String y)
 	{
 		ShaderVar v = new ShaderVar("vec2(" + x + ", " + y + ")", DataType.VEC2);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castVec2(ShaderVar x, ShaderVar y)
 	{
 		return castVec2(x.getVarName(), y.getVarName());
 	}
-	
+
 	public ShaderVar castVec2(String x)
 	{
 		ShaderVar v = new ShaderVar("vec2(" + x + ")", DataType.VEC2);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castVec2(ShaderVar x)
 	{
 		return castVec2(x.getVarName());
 	}
-	
+
 	public ShaderVar castVec3(float x, float y, float z)
 	{
 		return castVec3(new RFloat(x), new RFloat(y), new RFloat(z));
 	}
-	
+
 	public ShaderVar castVec3(ShaderVar x, ShaderVar y, ShaderVar z)
 	{
 		ShaderVar v = new ShaderVar(DataType.VEC3);
@@ -1220,72 +1220,72 @@ public abstract class AShader extends AShaderBase {
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castVec3(String var)
 	{
 		ShaderVar v = new ShaderVar("vec3(" + var + ")", DataType.VEC3);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castVec3(ShaderVar var)
 	{
 		return castVec3(var.getVarName());
 	}
-	
+
 	public ShaderVar castVec4(float value)
 	{
 		return castVec4(Float.toString(value));
 	}
-	
+
 	public ShaderVar castVec4(ShaderVar var)
 	{
-		return castVec4(var.getVarName()); 		
+		return castVec4(var.getVarName());
 	}
-	
+
 	public ShaderVar castVec4(String var)
 	{
 		ShaderVar v = new ShaderVar("vec4(" + var + ")", DataType.VEC4);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castVec4(ShaderVar var, float value)
 	{
 		return castVec4(var.getVarName(), value);
 	}
-	
+
 	public ShaderVar castVec4(String var, float value)
 	{
 		ShaderVar v = new ShaderVar("vec4(" + var + ", " + value + ")", DataType.VEC4);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castMat3(float value)
 	{
 		return castMat3(new RFloat(value));
 	}
-	
+
 	public ShaderVar castMat3(ShaderVar var)
 	{
 		ShaderVar v = new ShaderVar("mat3(" + var.getName() + ")", DataType.MAT3);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar castMat4(float value)
 	{
 		return castMat4(new RFloat(Float.toString(value)));
 	}
-	
+
 	public ShaderVar castMat4(ShaderVar var)
 	{
 		ShaderVar v = new ShaderVar("mat4(" + var.getName() + ")", DataType.MAT3);
 		v.mInitialized = true;
 		return v;
 	}
-	
+
 	public ShaderVar enclose(ShaderVar value)
 	{
 		ShaderVar var = getReturnTypeForOperation(value.getDataType(), value.getDataType());
@@ -1293,11 +1293,11 @@ public abstract class AShader extends AShaderBase {
 		var.setName(var.getValue());
 		return var;
 	}
-	
+
 	public boolean needsBuild() {
 		return mNeedsBuild;
 	}
-	
+
 	public void setNeedsBuild(boolean needsBuild) {
 		mNeedsBuild = needsBuild;
 	}

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ASingleTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ASingleTexture.java
@@ -1,18 +1,16 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.rajawali3d.materials.textures;
-
-import java.nio.ByteBuffer;
 
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -21,13 +19,15 @@ import android.graphics.BitmapFactory;
 import android.opengl.GLES20;
 import android.opengl.GLUtils;
 
+import java.nio.ByteBuffer;
+
 /**
  * This class is used to specify texture options.
- * 
+ *
  * @author dennis.ippel
- * 
+ *
  */
-public abstract class ASingleTexture extends ATexture 
+public abstract class ASingleTexture extends ATexture
 {
 	protected Bitmap mBitmap;
 	protected ByteBuffer mByteBuffer;
@@ -54,12 +54,12 @@ public abstract class ASingleTexture extends ATexture
 		this(textureType, textureName);
 		setBitmap(bitmap);
 	}
-	
+
 	public ASingleTexture(TextureType textureType, String textureName, ACompressedTexture compressedTexture)
 	{
 		super(textureType, textureName, compressedTexture);
 	}
-	
+
 	public ASingleTexture(ASingleTexture other)
 	{
 		super(other);
@@ -73,7 +73,7 @@ public abstract class ASingleTexture extends ATexture
 
 	/**
 	 * Copies every property from another ATexture object
-	 * 
+	 *
 	 * @param other
 	 *            another ATexture object to copy from
 	 */
@@ -125,10 +125,9 @@ public abstract class ASingleTexture extends ATexture
 			setWidth(mCompressedTexture.getWidth());
 			setHeight(mCompressedTexture.getHeight());
 			setTextureId(mCompressedTexture.getTextureId());
-			setUniformHandle(mCompressedTexture.getUniformHandle());
 			return;
 		}
-		
+
 		if (mBitmap == null && (mByteBuffer == null || mByteBuffer.limit() == 0))
 			throw new TextureException("Texture could not be added because there is no Bitmap or ByteBuffer set.");
 
@@ -192,7 +191,7 @@ public abstract class ASingleTexture extends ATexture
 		} else {
 			throw new TextureException("Couldn't generate a texture name.");
 		}
-		
+
 		if (mShouldRecycle)
 		{
 			if (mBitmap != null)
@@ -225,10 +224,9 @@ public abstract class ASingleTexture extends ATexture
 			setWidth(mCompressedTexture.getWidth());
 			setHeight(mCompressedTexture.getHeight());
 			setTextureId(mCompressedTexture.getTextureId());
-			setUniformHandle(mCompressedTexture.getUniformHandle());
 			return;
 		}
-		
+
 		if (mBitmap == null && (mByteBuffer == null || mByteBuffer.limit() == 0))
 			throw new TextureException("Texture could not be replaced because there is no Bitmap or ByteBuffer set.");
 
@@ -241,7 +239,7 @@ public abstract class ASingleTexture extends ATexture
 				throw new TextureException("Texture could not be updated because the texture size is different from the original.");
 			if(bitmapFormat != mBitmapFormat)
 				throw new TextureException("Texture could not be updated because the bitmap format is different from the original");
-			
+
 			GLUtils.texSubImage2D(GLES20.GL_TEXTURE_2D, 0, 0, 0, mBitmap, mBitmapFormat, GLES20.GL_UNSIGNED_BYTE);
 		} else if(mByteBuffer != null) {
 			if (mWidth == 0 || mHeight == 0 || mBitmapFormat == 0)
@@ -255,7 +253,7 @@ public abstract class ASingleTexture extends ATexture
 
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 	}
-	
+
 	void reset() throws TextureException
 	{
 		if(mCompressedTexture != null)
@@ -263,7 +261,7 @@ public abstract class ASingleTexture extends ATexture
 			mCompressedTexture.reset();
 			return;
 		}
-		
+
 		if(mBitmap != null)
 		{
 			mBitmap.recycle();
@@ -275,7 +273,7 @@ public abstract class ASingleTexture extends ATexture
 			mByteBuffer = null;
 		}
 	}
-	
+
 	/**
 	 * @param wrapType
 	 *            the texture wrap type. See {@link WrapType}.

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
@@ -12,14 +12,15 @@
  */
 package org.rajawali3d.materials.textures;
 
+import android.graphics.Bitmap.Config;
+import android.opengl.GLES20;
+import android.support.annotation.NonNull;
+import org.rajawali3d.materials.Material;
+import org.rajawali3d.renderer.Renderer;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
-
-import org.rajawali3d.materials.Material;
-import org.rajawali3d.renderer.Renderer;
-import android.graphics.Bitmap.Config;
-import android.opengl.GLES20;
 
 public abstract class ATexture {
 	/**
@@ -63,10 +64,6 @@ public abstract class ATexture {
 	 */
 	protected int mTextureId = -1;
 	/**
-	 * The uniform handle represents the sampler location in the shader program
-	 */
-	protected int mUniformHandle = -1;
-	/**
 	 * Texture width
 	 */
 	protected int mWidth;
@@ -92,28 +89,28 @@ public abstract class ATexture {
 	 * OpenGL-specific data. This is used when the OpenGL context needs to be restored. The context typically needs to
 	 * be restored when the application is re-activated or when a live wallpaper is rotated.
 	 */
-	protected boolean mShouldRecycle;
+	protected          boolean     mShouldRecycle;
 	/**
 	 * The texture name that will be used in the shader.
 	 */
-	protected String mTextureName;
+	@NonNull protected String      mTextureName;
 	/**
 	 * The type of texture {link {@link TextureType}
 	 */
-	protected TextureType mTextureType;
+	protected          TextureType mTextureType;
 	/**
 	 * Texture wrap type. See {@link WrapType}.
 	 */
-	protected WrapType mWrapType;
+	protected          WrapType    mWrapType;
 	/**
 	 * Texture filtering type. See {@link FilterType}.
 	 */
-	protected FilterType mFilterType;
+	protected          FilterType  mFilterType;
 	/**
 	 * Possible bitmap configurations. A bitmap configuration describes how pixels are stored. This affects the quality
 	 * (color depth) as well as the ability to display transparent/translucent colors. See {@link Config}.
 	 */
-	protected Config mBitmapConfig;
+	protected          Config      mBitmapConfig;
 	/**
 	 * A list of materials that use this texture.
 	 */
@@ -141,7 +138,7 @@ public abstract class ATexture {
 	 *
 	 * @param textureType
 	 */
-	public ATexture(TextureType textureType, String textureName)
+	public ATexture(TextureType textureType, @NonNull String textureName)
 	{
 		this();
 		mTextureType = textureType;
@@ -152,7 +149,7 @@ public abstract class ATexture {
 		mFilterType = FilterType.LINEAR;
 	}
 
-	public ATexture(TextureType textureType, String textureName, ACompressedTexture compressedTexture)
+	public ATexture(TextureType textureType, @NonNull String textureName, ACompressedTexture compressedTexture)
 	{
 		this(textureType, textureName);
 		setCompressedTexture(compressedTexture);
@@ -186,7 +183,6 @@ public abstract class ATexture {
 	public void setFrom(ATexture other)
 	{
 		mTextureId = other.getTextureId();
-		mUniformHandle = other.getUniformHandle();
 		mWidth = other.getWidth();
 		mHeight = other.getHeight();
 		mBitmapFormat = other.getBitmapFormat();
@@ -215,21 +211,6 @@ public abstract class ATexture {
 	 */
 	public void setTextureId(int textureId) {
 		mTextureId = textureId;
-	}
-
-	/**
-	 * @return The uniform handle represents the sampler location in the shader program
-	 */
-	public int getUniformHandle() {
-		return mUniformHandle;
-	}
-
-	/**
-	 * @param mUniformHandle
-	 *            The uniform handle represents the sampler location in the shader program
-	 */
-	public void setUniformHandle(int uniformHandle) {
-		this.mUniformHandle = uniformHandle;
 	}
 
 	/**

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/RenderTargetTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/RenderTargetTexture.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -31,12 +31,12 @@ public class RenderTargetTexture extends ATexture {
 			return mFormat;
 		}
 	};
-	
+
 	public static enum RenderTargetTextureType
 	{
-		UNSIGNED_BYTE(GLES20.GL_UNSIGNED_BYTE), BYTE(GLES20.GL_BYTE), UNSIGNED_SHORT(GLES20.GL_UNSIGNED_SHORT), 
-		SHORT(GLES20.GL_SHORT), UNSIGNED_INT(GLES20.GL_UNSIGNED_INT), INT(GLES20.GL_INT), FLOAT(GLES20.GL_FLOAT);	
-		
+		UNSIGNED_BYTE(GLES20.GL_UNSIGNED_BYTE), BYTE(GLES20.GL_BYTE), UNSIGNED_SHORT(GLES20.GL_UNSIGNED_SHORT),
+		SHORT(GLES20.GL_SHORT), UNSIGNED_INT(GLES20.GL_UNSIGNED_INT), INT(GLES20.GL_INT), FLOAT(GLES20.GL_FLOAT);
+
 		private int mType;
 
 		RenderTargetTextureType(int type)
@@ -47,7 +47,7 @@ public class RenderTargetTexture extends ATexture {
 		public int getType() {
 			return mType;
 		}
-		
+
 	}
 
 	private RenderTargetTextureFormat mInternalFormat;

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/APass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/APass.java
@@ -17,7 +17,7 @@ import org.rajawali3d.materials.MaterialManager;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * Defines a rendering pass which is needed for multiple rendering passes.
@@ -57,7 +57,7 @@ public abstract class APass implements IPass {
 		return mNeedsSwap;
 	}
 
-	public abstract void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad,
+	public abstract void render(Scene scene, Renderer renderer, ScreenQuad screenQuad,
 								RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime);
 
 	public PassType getPassType() {

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/IPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/IPass.java
@@ -16,7 +16,7 @@ import org.rajawali3d.materials.Material;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 
 public interface IPass extends IPostProcessingComponent {
@@ -26,7 +26,7 @@ public interface IPass extends IPostProcessingComponent {
 
 	boolean isClear();
 	boolean needsSwap();
-	void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime);
+	void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime);
 	PassType getPassType();
 	void setMaterial(Material material);
 	void setRenderToScreen(boolean renderToScreen);

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/PostProcessingManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/PostProcessingManager.java
@@ -25,7 +25,7 @@ import org.rajawali3d.postprocessing.passes.EffectPass;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 import org.rajawali3d.scenegraph.IGraphNode.GRAPH_TYPE;
 
 import java.util.Collections;
@@ -50,7 +50,7 @@ public class PostProcessingManager {
 	protected EffectPass mCopyPass;
 
 	protected ScreenQuad mScreenQuad;
-	protected RajawaliScene mScene;
+	protected Scene      mScene;
 
 	public PostProcessingManager(Renderer renderer) {
 		this(renderer, -1, -1);
@@ -68,7 +68,7 @@ public class PostProcessingManager {
 		mHeight = height;
 
 		mScreenQuad = new ScreenQuad();
-		mScene = new RajawaliScene(mRenderer, GRAPH_TYPE.NONE);
+		mScene = new Scene(mRenderer, GRAPH_TYPE.NONE);
 
 		mRenderTarget1 = new RenderTarget("rt1" + hashCode(), width, height, 0, 0,
 				false, false, GLES20.GL_TEXTURE_2D, Config.ARGB_8888,
@@ -223,7 +223,7 @@ public class PostProcessingManager {
 		return mComponents.isEmpty();
 	}
 
-	public RajawaliScene getScene() {
+	public Scene getScene() {
 		return mScene;
 	}
 

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/effects/BloomEffect.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/effects/BloomEffect.java
@@ -21,15 +21,15 @@ import org.rajawali3d.postprocessing.passes.ColorThresholdPass;
 import org.rajawali3d.postprocessing.passes.CopyToNewRenderTargetPass;
 import org.rajawali3d.postprocessing.passes.RenderPass;
 import org.rajawali3d.renderer.Renderer;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 public class BloomEffect extends APostProcessingEffect {
-	private RajawaliScene mScene;
-	private Camera mCamera;
-	private int mWidth;
-	private int mHeight;
-	private int mLowerThreshold;
-	private int mUpperThreshold;
+	private Scene     mScene;
+	private Camera    mCamera;
+	private int       mWidth;
+	private int       mHeight;
+	private int       mLowerThreshold;
+	private int       mUpperThreshold;
 	private BlendMode mBlendMode;
 
 	/**
@@ -45,7 +45,7 @@ public class BloomEffect extends APostProcessingEffect {
 	 * @param upperThreshold
 	 * @param blendMode
 	 */
-	public BloomEffect(RajawaliScene scene, Camera camera, int width, int height, int lowerThreshold, int upperThreshold, BlendMode blendMode) {
+	public BloomEffect(Scene scene, Camera camera, int width, int height, int lowerThreshold, int upperThreshold, BlendMode blendMode) {
 		super();
 		mScene = scene;
 		mCamera = camera;

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/effects/ShadowEffect.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/effects/ShadowEffect.java
@@ -10,21 +10,21 @@ import org.rajawali3d.postprocessing.passes.ShadowPass;
 import org.rajawali3d.postprocessing.passes.ShadowPass.ShadowPassType;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 import android.graphics.Bitmap.Config;
 import android.opengl.GLES20;
 
 
 public class ShadowEffect extends APostProcessingEffect {
-	private RajawaliScene mScene;
-	private Camera mCamera;
-	private DirectionalLight mLight;
-	private int mShadowMapSize;
-	private RenderTarget mShadowRenderTarget;
-	private float mShadowInfluence;
+	private Scene             mScene;
+	private Camera            mCamera;
+	private DirectionalLight  mLight;
+	private int               mShadowMapSize;
+	private RenderTarget      mShadowRenderTarget;
+	private float             mShadowInfluence;
 	private ShadowMapMaterial mShadowMapMaterial;
 
-	public ShadowEffect(RajawaliScene scene, Camera camera, DirectionalLight light, int shadowMapSize) {
+	public ShadowEffect(Scene scene, Camera camera, DirectionalLight light, int shadowMapSize) {
 		super();
 		mScene = scene;
 		mCamera = camera;

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/BlendPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/BlendPass.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -13,36 +13,42 @@
 package org.rajawali3d.postprocessing.passes;
 
 import org.rajawali3d.R;
+import org.rajawali3d.materials.Material;
 import org.rajawali3d.materials.textures.ATexture;
 
 
 public class BlendPass extends EffectPass {
-	protected ATexture mBlendTexture;
-	
-	public static enum BlendMode {
-		ADD, SCREEN
-	};
-	
-	public BlendPass(BlendMode blendMode, ATexture blendTexture) {
-		super();
-		createMaterial(R.raw.minimal_vertex_shader, getFragmentShader(blendMode));
-		mBlendTexture = blendTexture;
-	}
-	
-	protected int getFragmentShader(BlendMode blendMode) {
-		switch(blendMode) {
-		case ADD:
-			return R.raw.blend_add_fragment_shader;
-		case SCREEN:
-			return R.raw.blend_screen_fragment_shader;
-		default:
-			return R.raw.blend_add_fragment_shader;
-		}
-	}
-	
-	public void setShaderParams()
-	{
-		super.setShaderParams();
-		mMaterial.bindTextureByName(PARAM_BLEND_TEXTURE, 1, mBlendTexture);		
-	}
+    protected ATexture mBlendTexture;
+
+    public static enum BlendMode {
+        ADD, SCREEN
+    }
+
+    public BlendPass(BlendMode blendMode, ATexture blendTexture) {
+        super();
+        createMaterial(R.raw.minimal_vertex_shader, getFragmentShader(blendMode));
+        mBlendTexture = blendTexture;
+    }
+
+    @Override
+    public void setMaterial(Material material) {
+        super.setMaterial(material);
+        material.setTextureHandleForName(PARAM_BLEND_TEXTURE);
+    }
+
+    protected int getFragmentShader(BlendMode blendMode) {
+        switch (blendMode) {
+            case ADD:
+                return R.raw.blend_add_fragment_shader;
+            case SCREEN:
+                return R.raw.blend_screen_fragment_shader;
+            default:
+                return R.raw.blend_add_fragment_shader;
+        }
+    }
+
+    public void setShaderParams() {
+        super.setShaderParams();
+        mMaterial.bindTextureByName(PARAM_BLEND_TEXTURE, 1, mBlendTexture);
+    }
 }

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/ClearMaskPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/ClearMaskPass.java
@@ -18,7 +18,7 @@ import org.rajawali3d.postprocessing.APass;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * Disables stencil test for previously masked rendering passes so that
@@ -31,7 +31,7 @@ public class ClearMaskPass extends APass {
 	}
 
 	@Override
-	public void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
+	public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		// Disable stencil test so next rendering pass won't be masked.
 		GLES20.glDisable(GLES20.GL_STENCIL_TEST);
 	}

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/CopyToNewRenderTargetPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/CopyToNewRenderTargetPass.java
@@ -21,7 +21,7 @@ import org.rajawali3d.materials.textures.ATexture.WrapType;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 public class CopyToNewRenderTargetPass extends EffectPass {
 	private RenderTarget mRenderTarget;
@@ -41,7 +41,7 @@ public class CopyToNewRenderTargetPass extends EffectPass {
 		return mRenderTarget;
 	}
 
-	public void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime) {
+	public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime) {
 		super.render(scene, renderer, screenQuad, mRenderTarget, readTarget, ellapsedTime, deltaTime);
 	}
 

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/DepthPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/DepthPass.java
@@ -9,16 +9,16 @@ import org.rajawali3d.postprocessing.APass;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 
 public class DepthPass extends APass {
-	protected RajawaliScene mScene;
-	protected Camera mCamera;
-	protected Camera mOldCamera;
+	protected Scene               mScene;
+	protected Camera              mCamera;
+	protected Camera              mOldCamera;
 	protected DepthMaterialPlugin mDepthPlugin;
 
-	public DepthPass(RajawaliScene scene, Camera camera) {
+	public DepthPass(Scene scene, Camera camera) {
 		mPassType = PassType.DEPTH;
 		mScene = scene;
 		mCamera = camera;
@@ -34,7 +34,7 @@ public class DepthPass extends APass {
 	}
 
 	@Override
-	public void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget,
+	public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget,
 					   RenderTarget readTarget, long ellapsedTime, double deltaTime) {
 		GLES20.glClearColor(0, 0, 0, 1);
 		mDepthPlugin.setFarPlane((float)mCamera.getFarPlane());

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/EffectPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/EffectPass.java
@@ -19,7 +19,7 @@ import org.rajawali3d.postprocessing.APass;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 
 public class EffectPass extends APass {
@@ -64,7 +64,7 @@ public class EffectPass extends APass {
 		mMaterial.bindTextureByName(PARAM_TEXTURE, 0, mReadTarget.getTexture());
 	}
 
-	public void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime) {
+	public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget, RenderTarget readTarget, long ellapsedTime, double deltaTime) {
 		mReadTarget = readTarget;
 		mWriteTarget = writeTarget;
 		screenQuad.setMaterial(mMaterial);

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/EffectPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/EffectPass.java
@@ -17,8 +17,8 @@ import org.rajawali3d.materials.shaders.FragmentShader;
 import org.rajawali3d.materials.shaders.VertexShader;
 import org.rajawali3d.postprocessing.APass;
 import org.rajawali3d.primitives.ScreenQuad;
-import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
+import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.scene.Scene;
 
 

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/MaskPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/MaskPass.java
@@ -21,17 +21,17 @@ import org.rajawali3d.postprocessing.APass;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * Masked render pass for drawing to stencil buffer.
  * @author Andrew Jo (andrewjo@gmail.com / www.andrewjo.com)
  */
 public class MaskPass extends APass {
-	protected RajawaliScene mScene;
+	protected Scene   mScene;
 	protected boolean mInverse;
 
-	public MaskPass(RajawaliScene scene) {
+	public MaskPass(Scene scene) {
 		mPassType = PassType.MASK;
 		mScene = scene;
 		mEnabled = true;
@@ -57,7 +57,7 @@ public class MaskPass extends APass {
 	}
 
 	@Override
-	public void render(RajawaliScene scene, Renderer render, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
+	public void render(Scene scene, Renderer render, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		// Do not update color or depth.
 		GLES20.glColorMask(false, false, false, false);
 		GLES20.glDepthMask(false);

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/RenderPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/RenderPass.java
@@ -20,7 +20,7 @@ import org.rajawali3d.postprocessing.APass;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * A render pass used for primarily rendering a scene to a framebuffer target.
@@ -28,18 +28,18 @@ import org.rajawali3d.scene.RajawaliScene;
  * @author dennis.ippel
  */
 public class RenderPass extends APass {
-	protected RajawaliScene mScene;
+	protected Scene  mScene;
 	protected Camera mCamera;
 	protected Camera mOldCamera;
-	protected int mClearColor;
-	protected int mOldClearColor;
+	protected int    mClearColor;
+	protected int    mOldClearColor;
 
 	/**
 	 * Instantiates a new RenderPass object.
-	 * @param scene RajawaliScene instance to render for this pass
+	 * @param scene Scene instance to render for this pass
 	 * @param clearColor Color of the background to clear before rendering the scene
 	 */
-	public RenderPass(RajawaliScene scene, Camera camera, int clearColor) {
+	public RenderPass(Scene scene, Camera camera, int clearColor) {
 		mPassType = PassType.RENDER;
 		mScene = scene;
 		mCamera = camera;
@@ -51,7 +51,7 @@ public class RenderPass extends APass {
 		mNeedsSwap = true;
 	}
 
-	public void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
+	public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		// Set the background color with that of current render pass.
 		if (mClearColor != 0x00000000) {
 			mOldClearColor = renderer.getCurrentScene().getBackgroundColor();

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/ShadowPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/ShadowPass.java
@@ -6,7 +6,7 @@ import org.rajawali3d.postprocessing.materials.ShadowMapMaterial;
 import org.rajawali3d.primitives.ScreenQuad;
 import org.rajawali3d.renderer.Renderer;
 import org.rajawali3d.renderer.RenderTarget;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 
 public class ShadowPass extends RenderPass {
@@ -20,7 +20,7 @@ public class ShadowPass extends RenderPass {
 	private ShadowMapMaterial mShadowMapMaterial;
 	private ShadowPassType mShadowPassType;
 
-	public ShadowPass(ShadowPassType shadowPassType, RajawaliScene scene, Camera camera, DirectionalLight light, RenderTarget renderTarget) {
+	public ShadowPass(ShadowPassType shadowPassType, Scene scene, Camera camera, DirectionalLight light, RenderTarget renderTarget) {
 		super(scene, camera, 0);
 		mShadowPassType = shadowPassType;
 		mShadowRenderTarget = renderTarget;
@@ -35,7 +35,7 @@ public class ShadowPass extends RenderPass {
 	}
 
 	@Override
-	public void render(RajawaliScene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
+	public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeBuffer, RenderTarget readBuffer, long ellapsedTime, double deltaTime) {
 		if(mShadowPassType == ShadowPassType.APPLY_SHADOW_MAP) {
 			mShadowMapMaterial.setShadowMapTexture(mShadowRenderTarget.getTexture());
 			super.render(scene, renderer, screenQuad, writeBuffer, readBuffer, ellapsedTime, deltaTime);

--- a/rajawali/src/main/java/org/rajawali3d/renderer/PipRenderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/PipRenderer.java
@@ -18,7 +18,7 @@ import org.rajawali3d.materials.Material;
 import org.rajawali3d.materials.textures.ATexture;
 import org.rajawali3d.renderer.pip.SubRenderer;
 import org.rajawali3d.renderer.pip.WorkaroundScreenQuad;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * <p>
@@ -41,7 +41,7 @@ public class PipRenderer extends Renderer {
     private Material mMiniQuadMaterial;
     private Material mMainQuadMaterial;
 
-    private RajawaliScene mCompositeScene;
+    private Scene mCompositeScene;
 
     private SubRenderer mMiniRenderer;
     private SubRenderer mMainRenderer;

--- a/rajawali/src/main/java/org/rajawali3d/renderer/RenderTarget.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/RenderTarget.java
@@ -1,29 +1,29 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
 package org.rajawali3d.renderer;
 
+import android.graphics.Bitmap.Config;
+import android.opengl.GLES20;
+import android.opengl.GLU;
 import org.rajawali3d.materials.textures.ATexture.FilterType;
 import org.rajawali3d.materials.textures.ATexture.WrapType;
 import org.rajawali3d.materials.textures.RenderTargetTexture;
 import org.rajawali3d.materials.textures.TextureManager;
 import org.rajawali3d.util.RajLog;
-import android.graphics.Bitmap.Config;
-import android.opengl.GLES20;
-import android.opengl.GLU;
 
 /**
  * Defines configurations for a given render target.
- * 
+ *
  * @author Andrew Jo (andrewjo@gmail.com)
  * @author dennis.ippel
  */
@@ -51,7 +51,7 @@ public class RenderTarget {
 
 	/**
 	 * Instantiates a new RenderTarget object
-	 * 
+	 *
 	 * @param name
 	 *            The name of the render target. This should be unique and should comply with regular variable naming
 	 *            standards.
@@ -63,8 +63,6 @@ public class RenderTarget {
 	 *            Horizontal offset of the render target
 	 * @param offsetY
 	 *            Vertical offset of the render target
-	 * @param depthBuffer
-	 *            Set to true to enable depth buffer
 	 * @param stencilBuffer
 	 *            Set to true to enable stencil buffer
 	 * @param mipmaps
@@ -93,19 +91,20 @@ public class RenderTarget {
 		mBitmapConfig = bitmapConfig;
 		mFilterType = filterType;
 		mWrapType = wrapType;
-		
+
 		mTexture = new RenderTargetTexture(mName + "FBTex", mWidth, mHeight);
 		mTexture.setMipmap(mMipmaps);
 		mTexture.setGLTextureType(mGLType);
 		mTexture.setBitmapConfig(mBitmapConfig);
 		mTexture.setFilterType(mFilterType);
 		mTexture.setWrapType(mWrapType);
+		TextureManager.getInstance().addTexture(mTexture);
 	}
-	
+
 
 	/**
 	 * Instantiates a new RenderTarget object with default values
-	 * 
+	 *
 	 * @param width
 	 *            Width of the render target
 	 * @param height
@@ -134,7 +133,7 @@ public class RenderTarget {
 
 	/**
 	 * Returns whether stencil buffer has been enabled for this render target.
-	 * 
+	 *
 	 * @return True if stencil buffer is enabled, false otherwise.
 	 */
 	public boolean isStencilBufferEnabled() {
@@ -143,7 +142,7 @@ public class RenderTarget {
 
 	/**
 	 * Sets whether stencil buffer is enabled.
-	 * 
+	 *
 	 * @param stencilBuffer
 	 *            Set to true to enable stencil buffer.
 	 */
@@ -153,7 +152,7 @@ public class RenderTarget {
 
 	/**
 	 * Returns the current texture height for this render target.
-	 * 
+	 *
 	 * @return The current texture height in pixels.
 	 */
 	public int getHeight() {
@@ -162,7 +161,7 @@ public class RenderTarget {
 
 	/**
 	 * Sets the current texture height for this render target.
-	 * 
+	 *
 	 * @param height
 	 *            The current texture height in pixels. Set the dimension to power of two unless NPOT extensions are
 	 *            supported.
@@ -174,7 +173,7 @@ public class RenderTarget {
 
 	/**
 	 * Returns the horizontal value of the current texture offset coordinate.
-	 * 
+	 *
 	 * @return The x component of the offset coordinate.
 	 */
 	public int getOffsetX() {
@@ -183,7 +182,7 @@ public class RenderTarget {
 
 	/**
 	 * Sets the horizontal value of the current texture offset coordinate.
-	 * 
+	 *
 	 * @param offsetX
 	 *            The x component of the offset coordinate.
 	 */
@@ -193,7 +192,7 @@ public class RenderTarget {
 
 	/**
 	 * Returns the vertical value of the current texture offset coordinate.
-	 * 
+	 *
 	 * @return The y component of the offset coordinate.
 	 */
 	public int getOffsetY() {
@@ -202,7 +201,7 @@ public class RenderTarget {
 
 	/**
 	 * Sets the vertical value of the current texture offset coordinate.
-	 * 
+	 *
 	 * @param offsetY
 	 *            The y component of the offset coordinate.
 	 */
@@ -212,7 +211,7 @@ public class RenderTarget {
 
 	/**
 	 * Returns the current texture width for this render target.
-	 * 
+	 *
 	 * @return The current texture width in pixels.
 	 */
 	public int getWidth() {
@@ -221,7 +220,7 @@ public class RenderTarget {
 
 	/**
 	 * Sets the current texture width for this render target.
-	 * 
+	 *
 	 * @param width
 	 *            The current texture width in pixels. Set the dimension to power of two unless NPOT extensions are
 	 *            supported.
@@ -242,22 +241,22 @@ public class RenderTarget {
 		// -- add the texture directly. we can afford to do this because the create()
 		//    method is called in a thread safe manner.
 		TextureManager.getInstance().taskAdd(mTexture);
-				
+
 		GLES20.glFramebufferTexture2D(
 			      GLES20.GL_FRAMEBUFFER, GLES20.GL_COLOR_ATTACHMENT0, GLES20.GL_TEXTURE_2D, mTexture.getTextureId(), 0);
-		
+
 		checkGLError("Could not create framebuffer 2: ");
-		
+
 		GLES20.glGenRenderbuffers(1, bufferHandles, 0);
 		GLES20.glBindRenderbuffer(GLES20.GL_RENDERBUFFER, bufferHandles[0]);
 		GLES20.glRenderbufferStorage(GLES20.GL_RENDERBUFFER, GLES20.GL_DEPTH_COMPONENT16, mWidth, mHeight);
 		GLES20.glFramebufferRenderbuffer(GLES20.GL_FRAMEBUFFER, GLES20.GL_DEPTH_ATTACHMENT, GLES20.GL_RENDERBUFFER, bufferHandles[0]);
-		
+
 		checkGLError("Could not create framebuffer 3: ");
 /*
 		if (mStencilBuffer)
 		{
-			
+
 			GLES20.glGenRenderbuffers(1, bufferHandles, 0);
 			mStencilBufferHandle = bufferHandles[0];
 			GLES20.glBindRenderbuffer(GLES20.GL_RENDERBUFFER, mStencilBufferHandle);
@@ -275,7 +274,7 @@ public class RenderTarget {
 		GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, mFrameBufferHandle);
 		GLES20.glFramebufferTexture2D(
 			      GLES20.GL_FRAMEBUFFER, GLES20.GL_COLOR_ATTACHMENT0, GLES20.GL_TEXTURE_2D, mTexture.getTextureId(), 0);
-		
+
 		int status = GLES20.glCheckFramebufferStatus(GLES20.GL_FRAMEBUFFER);
 		if (status != GLES20.GL_FRAMEBUFFER_COMPLETE) {
 			GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0);
@@ -325,11 +324,11 @@ public class RenderTarget {
 	public void setFullscreen(boolean fullscreen) {
 		mFullscreen = fullscreen;
 	}
-	
+
 	public boolean getFullscreen() {
 		return mFullscreen;
 	}
-	
+
 	public RenderTargetTexture getTexture() {
 		return mTexture;
 	}
@@ -337,7 +336,7 @@ public class RenderTarget {
 	public int getFrameBufferHandle() {
 		return mFrameBufferHandle;
 	}
-	
+
 	public String getName() {
 		return mName;
 	}

--- a/rajawali/src/main/java/org/rajawali3d/renderer/SideBySideRenderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/SideBySideRenderer.java
@@ -23,7 +23,7 @@ import org.rajawali3d.materials.textures.ATexture.TextureException;
 import org.rajawali3d.math.Quaternion;
 import org.rajawali3d.math.vector.Vector3.Axis;
 import org.rajawali3d.primitives.ScreenQuad;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * <p>
@@ -112,7 +112,7 @@ public abstract class SideBySideRenderer extends Renderer {
 	 * Half the width of the viewport. The screen will be split in two.
 	 * One half for the left eye and one half for the right eye.
 	 */
-	private int mViewportWidthHalf;
+	private int          mViewportWidthHalf;
 	/**
 	 * The texture that will be used to render the scene into from the
 	 * perspective of the left eye.
@@ -126,30 +126,30 @@ public abstract class SideBySideRenderer extends Renderer {
 	/**
 	 * Used to store a reference to the user's scene.
 	 */
-	private RajawaliScene mUserScene;
+	private Scene        mUserScene;
 	/**
 	 * The side by side scene is what will finally be shown onto the screen.
 	 * This scene contains two quads. The left quad is the scene as viewed
 	 * from the left eye. The right quad is the scene as viewed from the
 	 * right eye.
 	 */
-	private RajawaliScene mSideBySideScene;
+	private Scene        mSideBySideScene;
 	/**
 	 * This screen quad will contain the scene as viewed from the left eye.
 	 */
-	private ScreenQuad mLeftQuad;
+	private ScreenQuad   mLeftQuad;
 	/**
 	 * This screen quad will contain the scene as viewed from the right eye.
 	 */
-	private ScreenQuad mRightQuad;
+	private ScreenQuad   mRightQuad;
 	/**
 	 * The material for the left quad
 	 */
-	private Material mLeftQuadMaterial;
+	private Material     mLeftQuadMaterial;
 	/**
 	 * The material for the right quad
 	 */
-	private Material mRightQuadMaterial;
+	private Material     mRightQuadMaterial;
 	/**
 	 * The distance between the pupils. This is used to offset the cameras.
 	 */
@@ -187,7 +187,7 @@ public abstract class SideBySideRenderer extends Renderer {
 		mRightQuadMaterial = new Material();
 		mRightQuadMaterial.setColorInfluence(0);
 
-		mSideBySideScene = new RajawaliScene(this);
+		mSideBySideScene = new Scene(this);
 
 		mLeftQuad = new ScreenQuad();
 		mLeftQuad.setScaleX(.5);

--- a/rajawali/src/main/java/org/rajawali3d/renderer/pip/SubRenderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/pip/SubRenderer.java
@@ -15,23 +15,23 @@ import android.view.MotionEvent;
 
 import org.rajawali3d.cameras.Camera;
 import org.rajawali3d.renderer.Renderer;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 /**
  * This class is intended to be used with <code>PipRenderer</code>.
  */
 public abstract class SubRenderer {
     private static final String TAG = "SubRenderer";
-    private RajawaliScene scene;
-    private Renderer      renderer;
+    private Scene    scene;
+    private Renderer renderer;
 
     public SubRenderer(Renderer renderer) {
-        scene = new RajawaliScene(renderer);
+        scene = new Scene(renderer);
         renderer.addScene(scene);
         this.renderer = renderer;
     }
 
-    public RajawaliScene getCurrentScene() {
+    public Scene getCurrentScene() {
         return scene;
     }
 

--- a/rajawali/src/main/java/org/rajawali3d/scene/ASceneFrameCallback.java
+++ b/rajawali/src/main/java/org/rajawali3d/scene/ASceneFrameCallback.java
@@ -1,7 +1,7 @@
 package org.rajawali3d.scene;
 
 /**
- * Abstract class for receiving frame callbacks from {@link RajawaliScene}. The timing
+ * Abstract class for receiving frame callbacks from {@link Scene}. The timing
  * of this interface assumes that the rendering time does not affect the timing of
  * operations before and after the frame. Pre- and Post- operations are provided
  * because of how these tie in with the animation system. Pre- tasks will be executed

--- a/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
+++ b/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
@@ -62,7 +62,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
  * @author Jared Woolston (jwoolston@tenkiv.com)
  */
 @SuppressWarnings("StatementWithEmptyBody")
-public class RajawaliScene {
+public class Scene {
 
 	protected final int GL_COVERAGE_BUFFER_BIT_NV = 0x8000;
 	protected double mEyeZ = 4.0; //TODO: Is this necessary?
@@ -136,7 +136,7 @@ public class RajawaliScene {
 	protected IGraphNode mSceneGraph; //The scenegraph for this scene
 	protected GRAPH_TYPE mSceneGraphType = GRAPH_TYPE.NONE; //The type of graph type for this scene.
 
-	public RajawaliScene(Renderer renderer) {
+	public Scene(Renderer renderer) {
 		mRenderer = renderer;
 		mAlpha = 0;
 		mAnimations = Collections.synchronizedList(new CopyOnWriteArrayList<Animation>());
@@ -156,7 +156,7 @@ public class RajawaliScene {
         mAntiAliasingConfig = ISurface.ANTI_ALIASING_CONFIG.NONE; // Default to none
 	}
 
-	public RajawaliScene(Renderer renderer, GRAPH_TYPE type) {
+	public Scene(Renderer renderer, GRAPH_TYPE type) {
 		this(renderer);
 		mSceneGraphType = type;
 		initSceneGraph();
@@ -235,7 +235,7 @@ public class RajawaliScene {
 	* with extreme caution.
 	*
 	* @return {@link Camera} object currently used for the scene.
-	* @see {@link RajawaliScene#mCamera}
+	* @see {@link Scene#mCamera}
 	*/
 	public Camera getCamera() {
 		return this.mCamera;

--- a/rajawali/src/main/java/org/rajawali3d/scenegraph/IGraphNode.java
+++ b/rajawali/src/main/java/org/rajawali3d/scenegraph/IGraphNode.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2013 Dennis Ippel
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
- * 
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
@@ -18,152 +18,152 @@ import org.rajawali3d.cameras.Camera;
 import org.rajawali3d.bounds.IBoundingVolume;
 import org.rajawali3d.math.Matrix4;
 import org.rajawali3d.math.vector.Vector3;
-import org.rajawali3d.scene.RajawaliScene;
+import org.rajawali3d.scene.Scene;
 
 
 /**
  * Generic interface allowing for the incorporation of scene graphs
  * to the rendering pipeline of Rajawali. To be a member of scene graphs
- * which implement this interface, an object must inherit from 
- * ATransformable3D. 
- * 
+ * which implement this interface, an object must inherit from
+ * ATransformable3D.
+ *
  * @author Jared Woolston (jwoolston@tenkiv.com)
  */
 public interface IGraphNode {
-	
+
 	/**
-	 * This enum defines the different scene graphs which {@link RajawaliScene}
-	 * can use. If a new type is created it should be added to this list. 
+	 * This enum defines the different scene graphs which {@link Scene}
+	 * can use. If a new type is created it should be added to this list.
 	 */
 	public enum GRAPH_TYPE {
 		NONE, OCTREE
 	}
-	
+
 	/**
 	 * Adds an object to the scene graph. Implementations do not
 	 * need to support online adjustment of the scene graph, and
 	 * should clearly document what their add behavior is.
-	 * 
+	 *
 	 * @param object BaseObject3D to be added to the graph.
 	 */
 	public void addObject(IGraphNodeMember object);
-	
+
 	/**
 	 * Adds a collection of objects to the scene graph. Implementations
 	 * do not need to support online adustment of the scene graph, and
 	 * should clearly document what their add behavior is.
-	 * 
+	 *
 	 * @param objects Collection of {@link IGraphNodeMember} objects to add.
 	 */
 	public void addObjects(Collection<IGraphNodeMember> objects);
-	
+
 	/**
 	 * Removes an object from the scene graph. Implementations do not
 	 * need to support online adjustment of the scene graph, and should
-	 * clearly document what their removal behavior is. 
-	 * 
+	 * clearly document what their removal behavior is.
+	 *
 	 * @param object BaseObject3D to be removed from the graph.
 	 */
 	public void removeObject(IGraphNodeMember object);
-	
+
 	/**
 	 * Removes a collection of objects from the scene graph. Implementations do not
 	 * need to support online adjustment of the scene graph, and should
 	 * clearly document what thier removal behavior is.
-	 * 
+	 *
 	 * @param objects Collection of {@link IGraphNodeMember} objects to remove.
 	 */
 	public void removeObjects(Collection<IGraphNodeMember> objects);
-	
+
 	/**
 	 * This should be called whenever an object has moved in the scene.
 	 * Implementations should determine its new position in the graph.
-	 * 
+	 *
 	 * @param object BaseObject3D to re-examine.
 	 */
 	public void updateObject(IGraphNodeMember object);
-	
+
 	/**
 	 * Set the child addition behavior. Implementations are expected
 	 * to document their default behavior.
-	 * 
+	 *
 	 * @param recursive boolean Should the children be added recursively.
 	 */
 	public void addChildrenRecursively(boolean recursive);
-	
+
 	/**
 	 * Set the child removal behavior. Implementations are expected to
 	 * document their default behavior.
-	 * 
+	 *
 	 * @param recursive boolean Should the children be removed recursively.
 	 */
 	public void removeChildrenRecursively(boolean recursive);
-	
+
 	/**
 	 * Can be called to force a reconstruction of the scene graph
 	 * with all added children. This is useful if the scene graph
 	 * does not support online modification.
 	 */
 	public void rebuild();
-	
+
 	/**
 	 * Can be called to remove all objects from the scene graph.
 	 */
 	public void clear();
-	
+
 	/**
 	 * Called to cause the scene graph to determine which objects are
-	 * contained (even partially) by the provided volume. How this is 
+	 * contained (even partially) by the provided volume. How this is
 	 * done is left to the implementation.
-	 * 
+	 *
 	 * @param volume IBoundingVolume to test visibility against.
 	 */
 	public void cullFromBoundingVolume(IBoundingVolume volume);
-	
+
 	/**
 	 * Call this in the renderer to cause the scene graph to be
-	 * displayed. It is up to the implementation to determine 
+	 * displayed. It is up to the implementation to determine
 	 * the best way to accomplish this (draw volumes, write text,
 	 * log statements, etc.)
-	 * 
+	 *
 	 * @param display boolean indicating if the graph is to be displayed.
 	 */
 	public void displayGraph(Camera camera, Matrix4 vpMatrix, Matrix4 projMatrix, Matrix4 vMatrix);
-	
+
 	/**
 	 * Retrieve the minimum bounds of this scene.
-	 * 
+	 *
 	 * @return {@link Vector3} The components represent the minimum value in each axis.
 	 */
 	public Vector3 getSceneMinBound();
-	
+
 	/**
 	 * Retrieve the maximum bounds of this scene.
-	 * 
+	 *
 	 * @return {@link Vector3} The components represent the maximum value in each axis.
 	 */
 	public Vector3 getSceneMaxBound();
-	
+
 	/**
 	 * Retrieve the number of objects this node is aware of. This count should
 	 * be recursive, meaning each node should ask its children for a count and
 	 * return the sum of that count.
-	 * 
+	 *
 	 * @return int containing the object count.
 	 */
 	public int getObjectCount();
-	
+
 	/**
 	 * Does this volume fully contain the input volume.
-	 * 
+	 *
 	 * @param boundingVolume Volume to check containment of.
 	 * @return boolean result of containment test.
 	 */
 	public boolean contains(IBoundingVolume boundingVolume);
-	
+
 	/**
 	 * Is this volume fully contained by the input volume.
-	 * 
+	 *
 	 * @param boundingVolume Volume to check containment by.
 	 * @return boolean result of containment test.
 	 */


### PR DESCRIPTION
Stores texture handles in a hashmap keyed by texture name. This allows reusing textures between materials if the same names are used. An initial attempt to find the locations is made on first compiling a material but if the texture name is not known there (such as for post processing) then it will be cached on the first use.