### PR TITLE
PR for #1504

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/util/Capabilities.java
+++ b/rajawali/src/main/java/org/rajawali3d/util/Capabilities.java
@@ -72,28 +72,49 @@ public class Capabilities {
         final EGLDisplay display = egl.eglGetDisplay(EGL10.EGL_DEFAULT_DISPLAY);
 
         final int[] version = new int[2];
-        if (!egl.eglInitialize(display, version)) throw new IllegalStateException("Failed to initialize and EGL context while getting device capabilities.");
+        if (!egl.eglInitialize(display, version))
+            throw new IllegalStateException(
+                    "Failed to initialize an EGL context while getting device capabilities.");
         mEGLMajorVersion = version[0];
         mEGLMinorVersion = version[1];
         // RajLog.d("Device EGL Version: " + version[0] + "." + version[1]);
 
-        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN_MR2) {
-            // The API for GLES3 doesnt exist on this device
-            // RajLog.d("Device is API level cannot support OpenGL ES 3.");
-            mGLESMajorVersion = 2;
-        } else {
+        // Assume GLES 2 by default
+        mGLESMajorVersion = 2;
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR2) {
             // The API for GLES3 might exist, we need to check
             // RajLog.d("Attempting to get an OpenGL ES 3 config.");
-            final int[] configAttribs = {EGL10.EGL_RED_SIZE, 4, EGL10.EGL_GREEN_SIZE, 4, EGL10.EGL_BLUE_SIZE, 4,
-                EGL10.EGL_RENDERABLE_TYPE, EGLExt.EGL_OPENGL_ES3_BIT_KHR, EGL10.EGL_NONE};
 
-            final EGLConfig[] configs = new EGLConfig[10];
+            // Find out how many EGLConfigs exist
             final int[] num_config = new int[1];
-            egl.eglChooseConfig(display, configAttribs, configs, 10, num_config);
-            egl.eglTerminate(display);
-            mGLESMajorVersion = num_config[0] > 0 ? 3 : 2;
-        }
+            egl.eglGetConfigs(display, null, 0, num_config);
 
+            // Allocate and retrieve the EGLConfigs/handles
+            int configCount = num_config[0];
+            final EGLConfig[] configs = new EGLConfig[configCount];
+            egl.eglGetConfigs(display, configs, configCount, num_config);
+
+            // Check for a config that supports GLES 3 (using a manual search rather than
+            // eglChooseConfig(), which may simply ignore the new ES3 bit on older versions)
+            final int value[] = new int[1];
+            for (EGLConfig config : configs) {
+                egl.eglGetConfigAttrib(display, config, EGL10.EGL_RENDERABLE_TYPE, value);
+                if ((value[0] & EGLExt.EGL_OPENGL_ES3_BIT_KHR) != 0) {
+                    // TODO is this secondary check for color sizes useful?
+                    // We have at least one GLES 3 config, can now use eglChooseConfig()
+                    // to see if one of them has at least 4 bits per color
+                    final int[] configAttribs = {
+                            EGL10.EGL_RED_SIZE, 4, EGL10.EGL_GREEN_SIZE, 4, EGL10.EGL_BLUE_SIZE, 4,
+                            EGL10.EGL_RENDERABLE_TYPE, EGLExt.EGL_OPENGL_ES3_BIT_KHR, EGL10.EGL_NONE};
+                    value[0] = 0;
+                    egl.eglChooseConfig(display, configAttribs, configs, 1, value);
+                    mGLESMajorVersion = value[0] > 0 ? 3 : 2;
+                    break;
+                }
+            }
+        }
+        egl.eglTerminate(display);
         // RajLog.d("Determined GLES Major version to be: " + mGLESMajorVersion);
         sGLChecked = true;
     }


### PR DESCRIPTION
See commit message...

If the secondary check (for color bit sizes) is not useful as-is, I'll be happy to remove/modify it and retest.
I ran all the examples on my S3 and noted anything unusual in the attached file:

[issue-1504 example notes.txt](https://github.com/Rajawali/Rajawali/files/163926/issue-1504.example.notes.txt)

Of particular interest: ETC2 provides an appropriate message that ES 3 is not supported, and a Vuforia crash.

As an aside, libVuforia.so is getting (re)built every time even though it is under source control, and so shows up as modified. Is this intentional?

Let me know if there are any git/branching issues I've missed.