### PR TITLE
PR for #1607 - combining object color picking and post-processing

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/interactive/TouchAndDragFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/interactive/TouchAndDragFragment.java
@@ -14,7 +14,9 @@ import android.widget.TextView;
 import org.rajawali3d.Object3D;
 import org.rajawali3d.examples.R;
 import org.rajawali3d.examples.examples.AExampleFragment;
+import org.rajawali3d.lights.DirectionalLight;
 import org.rajawali3d.materials.Material;
+import org.rajawali3d.materials.methods.DiffuseMethod;
 import org.rajawali3d.math.Matrix4;
 import org.rajawali3d.math.vector.Vector3;
 import org.rajawali3d.primitives.Sphere;
@@ -107,7 +109,14 @@ public class TouchAndDragFragment extends AExampleFragment implements
 			mPicker.setOnObjectPickedListener(this);
 
 			try {
+				DirectionalLight light= new DirectionalLight(-1, 0, -1);
+				light.setPower(1.5f);
+				getCurrentScene().addLight(light);
+				getCurrentCamera().setPosition(0, 0, 4);
+
 				Material material = new Material();
+				material.enableLighting(true);
+				material.setDiffuseMethod(new DiffuseMethod.Lambert());
 
 				for (int i = 0; i < 20; i++) {
 					Sphere sphere = new Sphere(.3f, 12, 12);

--- a/examples/src/main/java/org/rajawali3d/examples/examples/interactive/TouchAndDragFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/interactive/TouchAndDragFragment.java
@@ -116,7 +116,7 @@ public class TouchAndDragFragment extends AExampleFragment implements
 					sphere.setX(-4 + (Math.random() * 8));
 					sphere.setY(-4 + (Math.random() * 8));
 					sphere.setZ(-2 + (Math.random() * -6));
-					sphere.setDrawingMode(GLES20.GL_LINE_LOOP);
+					sphere.setDrawingMode(GLES20.GL_TRIANGLES);
 					mPicker.registerObject(sphere);
 					getCurrentScene().addChild(sphere);
 				}

--- a/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
+++ b/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
@@ -15,6 +15,7 @@ package org.rajawali3d.scene;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.opengl.GLES20;
+import android.support.annotation.NonNull;
 
 import org.rajawali3d.cameras.Camera;
 import org.rajawali3d.Object3D;
@@ -90,7 +91,7 @@ public class Scene {
      * Guarded by {@link #mFrameTaskQueue}.
      */
 	private volatile boolean                mLightsDirty;
-	protected ColorPickerInfo               mPickerInfo;
+	protected volatile ColorPickerInfo      mPickerInfo;
 	protected boolean                       mReloadPickerInfo;
 	protected ISurface.ANTI_ALIASING_CONFIG mAntiAliasingConfig;
 	protected boolean mEnableDepthBuffer = true;
@@ -931,7 +932,7 @@ public class Scene {
 		mRenderer.getTextureManager().replaceTexture(cubemap);
 	}
 
-	public void requestColorPicking(ColorPickerInfo pickerInfo) {
+	public void requestColorPicking(@NonNull ColorPickerInfo pickerInfo) {
 		mPickerInfo = pickerInfo;
 	}
 

--- a/rajawali/src/main/java/org/rajawali3d/util/ObjectColorPicker.java
+++ b/rajawali/src/main/java/org/rajawali3d/util/ObjectColorPicker.java
@@ -71,24 +71,25 @@ public class ObjectColorPicker implements IObjectPicker {
 		if (mObjectLookup.contains(object)) {
 			mObjectLookup.remove(object);
 		}
+		object.setPickingColor(Object3D.UNPICKABLE);
 	}
 
 	public void getObjectAt(float x, float y) {
-		mRenderer.getCurrentScene().requestColorPickingTexture(new ColorPickerInfo(x, y, this));
+		mRenderer.getCurrentScene().requestColorPicking(new ColorPickerInfo(x, y, this));
 	}
 
 	public RenderTarget getRenderTarget() {
 		return mRenderTarget;
 	}
 
-	public static void createColorPickingTexture(ColorPickerInfo pickerInfo) {
+	public static void pickObject(ColorPickerInfo pickerInfo) {
 		final ObjectColorPicker picker = pickerInfo.getPicker();
 		final ByteBuffer pixelBuffer = ByteBuffer.allocateDirect(4);
 		pixelBuffer.order(ByteOrder.nativeOrder());
 
-		GLES20.glReadPixels(pickerInfo.getX(), picker.mRenderer.getDefaultViewportHeight()
-				- pickerInfo.getY(), 1, 1, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE,
-				pixelBuffer);
+		GLES20.glReadPixels(pickerInfo.getX(),
+				picker.mRenderer.getViewportHeight() - pickerInfo.getY(),
+				1, 1, GLES20.GL_RGBA, GLES20.GL_UNSIGNED_BYTE, pixelBuffer);
 		GLES20.glBindFramebuffer(GLES20.GL_FRAMEBUFFER, 0);
 		pixelBuffer.rewind();
 

--- a/rajawali/src/main/java/org/rajawali3d/util/ObjectColorPicker.java
+++ b/rajawali/src/main/java/org/rajawali3d/util/ObjectColorPicker.java
@@ -109,10 +109,9 @@ public class ObjectColorPicker implements IObjectPicker {
 
 	public class ColorPickerInfo {
 
-		private int mX;
-		private int mY;
-		private ObjectColorPicker mPicker;
-		private ByteBuffer mColorPickerBuffer;
+		private final int mX;
+		private final int mY;
+		private final ObjectColorPicker mPicker;
 
 		public ColorPickerInfo(float x, float y, ObjectColorPicker picker) {
 			mX = (int) x;
@@ -130,14 +129,6 @@ public class ObjectColorPicker implements IObjectPicker {
 
 		public int getY() {
 			return mY;
-		}
-
-		public void setColorPickerBuffer(ByteBuffer buffer) {
-			mColorPickerBuffer = buffer;
-		}
-
-		public ByteBuffer getColorPickerBuffer() {
-			return mColorPickerBuffer;
 		}
 	}
 


### PR DESCRIPTION
Fixes #1607 

## Change Summary
* Scene.java
 * added `doColorPicking()` to isolate color-picking render from normal render() control flow
 * renamed `requestColorPickingTexture()` to `requestColorPicking()` 
* Object3D.java
 * introduced `UNPICKABLE` color/index, made it a default value
 * updated `setPickingColor()`, removed `getPickingColor()`
 * eliminated `mIsPickingEnabled`, now check for `UNPICKABLE`
 * added `renderColorPicking()` for optimized/independent color-picking rendering of the `Object3D` and its children (per #1387)
* ObjectColorPicker.java
 * updated `unregisterObject()` to reset picking color to UNPICKABLE
 * renamed `createColorPickingTexture()` to `pickObject()`
 * in `pickObject()` call to `GLES20.glReadPixels()`, replaced `getDefaultViewportHieght()` with `getViewportHeight()`

## Testing:
* Examples: Object Picking, Touch & Drag now work, and all other examples appear to work same as on master branch
* Picking nested child objects: working on my app...
* Combined color-picking && post-processing: I quickly cut/paste the GreyScale Filter setup into the Object Picking example; monkeys are rendered grey, but seem to have `y = viewportHeight - y`; picking then appears to work as if screen was rendered correctly (e.g. picking the upper left monkey moves the lower left monkey, and vice versa). I can't think of any way the object picking could interfere with the filter renders before anything is even picked, so I think this may be a post-processing-only issue masked by the random nature of the objects in the post-processing examples (which therefore have no natural sense of up/down that would easily reveal the same behavior).

## Concerns
* I was pretty aggressive in optimizing the color-picking rendering methods;
 * setup blending and depth testing just once at the scene level
 * at the object level, eliminated matrix updates, checks/setups for textures, normals, vertex colors, etc.
* I'd really appreciate some more experienced eyes desk-checking my changes and optimizations.  One nice thing here is that if something needs to change, it (probably) _shouldn't_ affect any of the non-color-picking renders
* Haven't really thought about threading/concurrency issues. Probably needs to be e.g. a sync lock on references to `mPickingInfo` in `Scene.requestColorPicking()` and `Scene.render()`?

Any/all questions/suggestions welcome, as usual...