### PR TITLE
Fixes #1611

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/RenderToTextureFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/RenderToTextureFragment.java
@@ -128,13 +128,6 @@ public class RenderToTextureFragment extends AExampleFragment {
 			//
 			// -- Off screen rendering first. Render to texture.
 			//
-
-			//
-			// -- Change the viewport to the required texture size
-			//
-
-            setOverrideViewportDimensions(400, 400);
-
 			mEffects.render(ellapsedTime, deltaTime);
 			try {
 				if (mCurrentTexture != null)
@@ -150,12 +143,6 @@ public class RenderToTextureFragment extends AExampleFragment {
 			} catch (ATexture.TextureException e) {
 				e.printStackTrace();
 			}
-
-			//
-			// -- Change the viewport back to full screen
-			//
-
-			clearOverrideViewportDimensions();
 			super.onRender(ellapsedTime, deltaTime);
 		}
 	}

--- a/rajawali/src/main/java/org/rajawali3d/materials/AResourceManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/AResourceManager.java
@@ -13,7 +13,6 @@
 package org.rajawali3d.materials;
 
 import android.content.Context;
-
 import org.rajawali3d.renderer.Renderer;
 
 import java.util.List;

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/RenderTargetTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/RenderTargetTexture.java
@@ -16,142 +16,173 @@ import android.opengl.GLES20;
 
 public class RenderTargetTexture extends ATexture {
 
-	public static enum RenderTargetTextureFormat
-	{
-		RGBA(GLES20.GL_RGBA), RGB(GLES20.GL_RGB), DEPTH(GLES20.GL_DEPTH_COMPONENT), DEPTH16(GLES20.GL_DEPTH_COMPONENT16);
+    public static enum RenderTargetTextureFormat {
+        RGBA(GLES20.GL_RGBA), RGB(GLES20.GL_RGB), DEPTH(GLES20.GL_DEPTH_COMPONENT),
+        DEPTH16(GLES20.GL_DEPTH_COMPONENT16);
 
-		private int mFormat;
+        private int mFormat;
 
-		RenderTargetTextureFormat(int format)
-		{
-			mFormat = format;
-		}
+        RenderTargetTextureFormat(int format) {
+            mFormat = format;
+        }
 
-		public int getFormat() {
-			return mFormat;
-		}
-	};
+        public int getFormat() {
+            return mFormat;
+        }
+    }
 
-	public static enum RenderTargetTextureType
-	{
-		UNSIGNED_BYTE(GLES20.GL_UNSIGNED_BYTE), BYTE(GLES20.GL_BYTE), UNSIGNED_SHORT(GLES20.GL_UNSIGNED_SHORT),
-		SHORT(GLES20.GL_SHORT), UNSIGNED_INT(GLES20.GL_UNSIGNED_INT), INT(GLES20.GL_INT), FLOAT(GLES20.GL_FLOAT);
+    ;
 
-		private int mType;
+    public static enum RenderTargetTextureType {
+        UNSIGNED_BYTE(GLES20.GL_UNSIGNED_BYTE), BYTE(GLES20.GL_BYTE), UNSIGNED_SHORT(GLES20.GL_UNSIGNED_SHORT),
+        SHORT(GLES20.GL_SHORT), UNSIGNED_INT(GLES20.GL_UNSIGNED_INT), INT(GLES20.GL_INT), FLOAT(GLES20.GL_FLOAT);
 
-		RenderTargetTextureType(int type)
-		{
-			mType = type;
-		}
+        private int mType;
 
-		public int getType() {
-			return mType;
-		}
+        RenderTargetTextureType(int type) {
+            mType = type;
+        }
 
-	}
+        public int getType() {
+            return mType;
+        }
 
-	private RenderTargetTextureFormat mInternalFormat;
-	private RenderTargetTextureFormat mFormat;
-	private RenderTargetTextureType mType;
+    }
 
-	public RenderTargetTexture(RenderTargetTexture other)
-	{
-		super(other);
-	}
+    private RenderTargetTextureFormat mInternalFormat;
+    private RenderTargetTextureFormat mFormat;
+    private RenderTargetTextureType   mType;
 
-	public RenderTargetTexture(String textureName)
-	{
-		this(textureName, 32, 32);
-	}
+    public RenderTargetTexture(RenderTargetTexture other) {
+        super(other);
+    }
 
-	public RenderTargetTexture(String textureName, int width, int height)
-	{
-		this(textureName, width, height, RenderTargetTextureFormat.RGBA, RenderTargetTextureFormat.RGBA, RenderTargetTextureType.UNSIGNED_BYTE);
-	}
+    public RenderTargetTexture(String textureName) {
+        this(textureName, 32, 32);
+    }
 
-	public RenderTargetTexture(String textureName, int width, int height, RenderTargetTextureFormat internalFormat, RenderTargetTextureFormat format, RenderTargetTextureType type)
-	{
-		super(TextureType.RENDER_TARGET, textureName);
-		mInternalFormat = internalFormat;
-		mFormat = format;
-		mType = type;
-		mWidth = width;
-		mHeight = height;
-	}
+    public RenderTargetTexture(String textureName, int width, int height) {
+        this(textureName, width, height, RenderTargetTextureFormat.RGBA, RenderTargetTextureFormat.RGBA,
+             RenderTargetTextureType.UNSIGNED_BYTE);
+    }
 
-	@Override
-	public RenderTargetTexture clone() {
-		return new RenderTargetTexture(this);
-	}
+    public RenderTargetTexture(String textureName, int width, int height, RenderTargetTextureFormat internalFormat,
+                               RenderTargetTextureFormat format, RenderTargetTextureType type) {
+        super(TextureType.RENDER_TARGET, textureName);
+        mInternalFormat = internalFormat;
+        mFormat = format;
+        mType = type;
+        mWidth = width;
+        mHeight = height;
+    }
 
-	public void setFrom(RenderTargetTexture other)
-	{
-		super.setFrom(other);
-	}
+    @Override
+    public RenderTargetTexture clone() {
+        return new RenderTargetTexture(this);
+    }
 
-	@Override
-	void add() throws TextureException {
-		if (mWidth == 0 || mHeight == 0)
-			throw new TextureException(
-					"FrameBufferTexture could not be added because the width and/or height weren't specified.");
+    @Override public void setWidth(int width) {
+        super.setWidth(width);
+        TextureManager.getInstance().getRenderer().resizeRenderTarget(this);
+    }
 
-		int[] textures = new int[1];
-		GLES20.glGenTextures(1, textures, 0);
-		int textureId = textures[0];
+    @Override public void setHeight(int height) {
+        super.setHeight(height);
+        TextureManager.getInstance().getRenderer().resizeRenderTarget(this);
+    }
 
-		if (textureId > 0) {
-			GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);
+    /**
+     * Resizes this render target texture. This method should be preferred over {@link #setWidth(int)} and {@link #setHeight(int)}
+     * if both dimensions will be changing as it is more efficient than calling both seperately.
+     *
+     * @param width
+     * @param height
+     */
+    public void resize(int width, int height) {
+        mWidth = width;
+        mHeight = height;
+        TextureManager.getInstance().getRenderer().resizeRenderTarget(this);
+    }
 
-			if (isMipmap())
-			{
-				if (mFilterType == FilterType.LINEAR)
-					GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER,
-							GLES20.GL_LINEAR_MIPMAP_LINEAR);
-				else
-					GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER,
-							GLES20.GL_NEAREST_MIPMAP_NEAREST);
-			} else {
-				if (mFilterType == FilterType.LINEAR)
-					GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
-				else
-					GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
-			}
+    public void setFrom(RenderTargetTexture other) {
+        super.setFrom(other);
+    }
 
-			if (mFilterType == FilterType.LINEAR)
-				GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
-			else
-				GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
+    @Override void add() throws TextureException {
+        if (mWidth == 0 || mHeight == 0) {
+            throw new TextureException(
+                    "FrameBufferTexture could not be added because the width and/or height weren't specified.");
+        }
 
-			if (mWrapType == WrapType.REPEAT) {
-				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_REPEAT);
-				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_REPEAT);
-			} else {
-				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
-				GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
-			}
+        int[] textures = new int[1];
+        GLES20.glGenTextures(1, textures, 0);
+        int textureId = textures[0];
 
-			GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, mInternalFormat.getFormat(), mWidth, mHeight, 0, mFormat.getFormat(),
-					mType.getType(), null);
-			if (isMipmap())
-				GLES20.glGenerateMipmap(GLES20.GL_TEXTURE_2D);
+        if (textureId > 0) {
+            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, textureId);
 
-			GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
-			setTextureId(textureId);
-		}
-	}
+            if (isMipmap()) {
+                if (mFilterType == FilterType.LINEAR) {
+                    GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER,
+                                           GLES20.GL_LINEAR_MIPMAP_LINEAR);
+                } else {
+                    GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER,
+                                           GLES20.GL_NEAREST_MIPMAP_NEAREST);
+                }
+            } else {
+                if (mFilterType == FilterType.LINEAR) {
+                    GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_LINEAR);
+                } else {
+                    GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MIN_FILTER, GLES20.GL_NEAREST);
+                }
+            }
 
-	@Override
-	void remove() throws TextureException {
-		GLES20.glDeleteTextures(1, new int[] { mTextureId }, 0);
-	}
+            if (mFilterType == FilterType.LINEAR) {
+                GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_LINEAR);
+            } else {
+                GLES20.glTexParameterf(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_MAG_FILTER, GLES20.GL_NEAREST);
+            }
 
-	@Override
-	void replace() throws TextureException {
-		return;
-	}
+            if (mWrapType == WrapType.REPEAT) {
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_REPEAT);
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_REPEAT);
+            } else {
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_S, GLES20.GL_CLAMP_TO_EDGE);
+                GLES20.glTexParameteri(GLES20.GL_TEXTURE_2D, GLES20.GL_TEXTURE_WRAP_T, GLES20.GL_CLAMP_TO_EDGE);
+            }
 
-	void reset() throws TextureException
-	{
-		return;
-	}
+            GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, mInternalFormat.getFormat(), mWidth, mHeight, 0,
+                                mFormat.getFormat(),
+                                mType.getType(), null);
+            if (isMipmap()) {
+                GLES20.glGenerateMipmap(GLES20.GL_TEXTURE_2D);
+            }
+
+            GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+            setTextureId(textureId);
+        }
+    }
+
+    @Override void remove() throws TextureException {
+        GLES20.glDeleteTextures(1, new int[]{ mTextureId }, 0);
+    }
+
+    @Override void replace() throws TextureException {
+        return;
+    }
+
+    void resize() {
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, mTextureId);
+        GLES20.glTexImage2D(GLES20.GL_TEXTURE_2D, 0, mInternalFormat.getFormat(), mWidth, mHeight, 0,
+                            mFormat.getFormat(), mType.getType(), null);
+        if (isMipmap()) {
+            GLES20.glGenerateMipmap(GLES20.GL_TEXTURE_2D);
+        }
+
+        GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
+    }
+
+    void reset() throws TextureException {
+        return;
+    }
 }

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/TextureManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/TextureManager.java
@@ -263,6 +263,10 @@ public final class TextureManager extends AResourceManager {
 		}
 	}
 
+	public void taskResizeRenderTarget(RenderTargetTexture renderTargetTexture) {
+		renderTargetTexture.resize();
+	}
+
 	/**
 	 * Returns the number of textures currently managed.
 	 *

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/PostProcessingManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/PostProcessingManager.java
@@ -133,10 +133,8 @@ public class PostProcessingManager {
 	}
 
 	public void setSize(int width, int height) {
-		mRenderTarget1.setWidth(width);
-		mRenderTarget1.setHeight(height);
-		mRenderTarget2.setWidth(width);
-		mRenderTarget2.setHeight(height);
+		mRenderTarget1.resize(width, height);
+		mRenderTarget2.resize(width, height);
 
 		for(IPass pass : mPasses) {
 			pass.setSize(width, height);
@@ -156,6 +154,9 @@ public class PostProcessingManager {
 			updatePassesList();
 			mComponentsDirty = false;
 		}
+
+		// Set the viewport to the correct dimensions
+		mRenderer.setOverrideViewportDimensions(mWidth, mHeight);
 
 		mWriteBuffer = mRenderTarget1;
 		mReadBuffer = mRenderTarget2;
@@ -192,6 +193,9 @@ public class PostProcessingManager {
 			else if (type == PassType.CLEAR)
 				maskActive = false;
 		}
+
+		// Restore the viewport dimensions
+		mRenderer.clearOverrideViewportDimensions();
 	}
 
 	public ATexture getTexture() {

--- a/rajawali/src/main/java/org/rajawali3d/renderer/RenderTarget.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/RenderTarget.java
@@ -172,6 +172,19 @@ public class RenderTarget {
 	}
 
 	/**
+	 * Resizes this render target. This method should be preferred over {@link #setWidth(int)} and {@link #setHeight(int)}
+	 * if both dimensions will be changing as it is more efficient than calling both seperately.
+	 *
+	 * @param width
+	 * @param height
+	 */
+	public void resize(int width, int height) {
+		mWidth = width;
+		mHeight = height;
+		mTexture.resize(width, height);
+	}
+
+	/**
 	 * Returns the horizontal value of the current texture offset coordinate.
 	 *
 	 * @return The x component of the offset coordinate.

--- a/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
@@ -20,6 +20,7 @@ import android.opengl.GLES20;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
+import android.support.annotation.NonNull;
 import android.util.SparseArray;
 import android.view.WindowManager;
 
@@ -29,6 +30,7 @@ import org.rajawali3d.loader.async.IAsyncLoaderCallback;
 import org.rajawali3d.materials.Material;
 import org.rajawali3d.materials.MaterialManager;
 import org.rajawali3d.materials.textures.ATexture;
+import org.rajawali3d.materials.textures.RenderTargetTexture;
 import org.rajawali3d.materials.textures.TextureManager;
 import org.rajawali3d.math.Matrix;
 import org.rajawali3d.math.Matrix4;
@@ -492,10 +494,12 @@ public abstract class Renderer implements ISurfaceRenderer {
      * @param height {@code int} The viewport height in pixels.
      */
     public void setViewPort(int width, int height) {
-        mCurrentViewportWidth = width;
-        mCurrentViewportHeight = height;
-        mCurrentScene.updateProjectionMatrix(width, height);
-        GLES20.glViewport(0, 0, width, height);
+        if (width != mCurrentViewportWidth || height != mCurrentViewportHeight) {
+            mCurrentViewportWidth = width;
+            mCurrentViewportHeight = height;
+            mCurrentScene.updateProjectionMatrix(width, height);
+            GLES20.glViewport(0, 0, width, height);
+        }
     }
 
     public int getDefaultViewportWidth() {
@@ -515,6 +519,7 @@ public abstract class Renderer implements ISurfaceRenderer {
     public void setOverrideViewportDimensions(int width, int height) {
         mOverrideViewportWidth = width;
         mOverrideViewportHeight = height;
+        setViewPort(mOverrideViewportWidth, mOverrideViewportHeight);
     }
 
     public int getOverrideViewportWidth() {
@@ -910,6 +915,16 @@ public abstract class Renderer implements ISurfaceRenderer {
             @Override
             protected void doTask() {
                 mTextureManager.taskReset();
+            }
+        };
+        return internalOfferTask(task);
+    }
+
+    public boolean resizeRenderTarget(@NonNull final RenderTargetTexture renderTargetTexture) {
+        final AFrameTask task = new AFrameTask() {
+            @Override
+            protected void doTask() {
+                mTextureManager.taskResizeRenderTarget(renderTargetTexture);
             }
         };
         return internalOfferTask(task);


### PR DESCRIPTION
Fixes #1611. Adds a task call for resizing render target textures and updates the post processing manager to handle the size differences automatically.

Signed-off-by: Jared Woolston <jwoolston@tenkiv.com>