### PR TITLE
Fix for color-picking of nested child objects (see #1607)

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/interactive/ObjectPickingFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/interactive/ObjectPickingFragment.java
@@ -72,14 +72,22 @@ public class ObjectPickingFragment extends AExampleFragment implements OnTouchLi
                 final LoaderAWD parser = new LoaderAWD(mContext.getResources(), mTextureManager, R.raw.awd_suzanne);
                 parser.parse();
 
+                // Inserting a couple nested containers to test child picking;
+                // should appear/behave the same
+                Object3D container = new Object3D();
+                getCurrentScene().addChild(container);
+
+                Object3D container1 = new Object3D();
+                container1.setScale(.7f);
+                container1.setPosition(-1, 1, 0);
+                container.addChild(container1);
+
                 mMonkey1 = parser.getParsedObject();
 
-                mMonkey1.setScale(.7f);
-                mMonkey1.setPosition(-1, 1, 0);
                 mMonkey1.setRotY(0);
                 mMonkey1.setMaterial(material);
                 mMonkey1.setColor(0x0000ff);
-                getCurrentScene().addChild(mMonkey1);
+                container1.addChild(mMonkey1);
 
                 mMonkey2 = mMonkey1.clone();
                 mMonkey2.setScale(.7f);
@@ -87,7 +95,7 @@ public class ObjectPickingFragment extends AExampleFragment implements OnTouchLi
                 mMonkey2.setRotY(45);
                 mMonkey2.setMaterial(material);
                 mMonkey2.setColor(0x00ff00);
-                getCurrentScene().addChild(mMonkey2);
+                container.addChild(mMonkey2);
 
                 mMonkey3 = mMonkey1.clone();
                 mMonkey3.setScale(.7f);

--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -407,7 +407,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 		// Draw children without frustum test
 		for (int i = 0, j = mChildren.size(); i < j; i++) {
 			// Child rendering is independent of batching, and matrices already updated
-			mChildren.get(i).render(camera, vpMatrix, projMatrix, vMatrix, mMMatrix, pickingMaterial);
+			mChildren.get(i).renderColorPicking(camera, vpMatrix, projMatrix, vMatrix, pickingMaterial);
 		}
 
 		// No need to unbind textures, all done


### PR DESCRIPTION
This is embarrassing. I apparently muffed the testing for picking nested child objects (probably dropped the ball in properly updating my app - which uses nested children - with the new Rajawali library for the original branch).

- Object3D: correcting recursive call in renderColorPicking()!
- Enhancing ObjectPicking example with a couple of simple containers to better detect regressions of child picking...