### PR TITLE
Misc fixes/improvements to color-picking (due to investigating #1615)

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -331,14 +331,9 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 	 * Renders the object for color-picking
 	 *
 	 * @param camera The camera
-	 * @param vpMatrix {@link Matrix4} The view-projection matrix
-	 * @param projMatrix {@link Matrix4} The projection matrix
-	 * @param vMatrix {@link Matrix4} The view matrix
 	 * @param pickingMaterial The color-picking Material
 	 */
-	public void renderColorPicking(final Camera camera, final Matrix4 vpMatrix,
-								   final Matrix4 projMatrix, final Matrix4 vMatrix,
-								   final Material pickingMaterial) {
+	public void renderColorPicking(final Camera camera, final Material pickingMaterial) {
 		if (!mIsVisible && !mRenderChildrenAsBatch)
 			// Neither the object nor any of its children are visible
 			return;
@@ -380,7 +375,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 			pickingMaterial.setColor(mPickingColor);
 			pickingMaterial.applyParams();
 
-			// Free up the array buffer, just in case
+			// Unbind the array buffer
 			GLES20.glBindBuffer(GLES20.GL_ARRAY_BUFFER, 0);
 
 			// Apply this object's matrices to the pickingMaterial
@@ -388,7 +383,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 			pickingMaterial.setModelMatrix(mMMatrix);
 			pickingMaterial.setModelViewMatrix(mMVMatrix);
 
-			// draw the object using its picking color
+			// Draw the object using its picking color
 			int bufferType = mGeometry.getIndexBufferInfo().bufferType == Geometry3D.BufferType.SHORT_BUFFER ? GLES20.GL_UNSIGNED_SHORT : GLES20.GL_UNSIGNED_INT;
 			GLES20.glBindBuffer(GLES20.GL_ELEMENT_ARRAY_BUFFER, mGeometry.getIndexBufferInfo().bufferHandle);
 			GLES20.glDrawElements(mDrawingMode, mGeometry.getNumIndices(), bufferType, 0);
@@ -407,10 +402,10 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 		// Draw children without frustum test
 		for (int i = 0, j = mChildren.size(); i < j; i++) {
 			// Child rendering is independent of batching, and matrices already updated
-			mChildren.get(i).renderColorPicking(camera, vpMatrix, projMatrix, vMatrix, pickingMaterial);
+			mChildren.get(i).renderColorPicking(camera, pickingMaterial);
 		}
 
-		// No need to unbind textures, all done
+		// No textures to unbind, all done
 	}
 
 	/**

--- a/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
+++ b/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
@@ -1143,7 +1143,10 @@ public class Scene {
 		// Set background color (to Object3D.UNPICKABLE to prevent any conflicts)
 		GLES20.glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
 
-		// Clear buffers needed for color-picking
+		// Use the full depth range
+		GLES20.glClearDepthf(1.0f);
+
+		// Clear buffers used for color-picking
 		GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT | GLES20.GL_DEPTH_BUFFER_BIT);
 
 		// Get the picking material
@@ -1156,20 +1159,18 @@ public class Scene {
 		if (mSkybox != null && mSkybox.isPickingEnabled()) {
 			GLES20.glDisable(GLES20.GL_DEPTH_TEST);
 			GLES20.glDepthMask(false);
-			mSkybox.renderColorPicking(mCamera, mVPMatrix, mPMatrix, mVMatrix, pickingMaterial);
+			mSkybox.renderColorPicking(mCamera, pickingMaterial);
 		}
 
 		// Configure depth testing for child renders
 		GLES20.glEnable(GLES20.GL_DEPTH_TEST);
 		GLES20.glDepthFunc(GLES20.GL_LESS);
 		GLES20.glDepthMask(true);
-		GLES20.glClearDepthf(1.0f);
 
 		// Render all children using their picking colors
 		synchronized (mChildren) {
 			for (int i = 0, j = mChildren.size(); i < j; ++i) {
-				mChildren.get(i).renderColorPicking(
-						mCamera, mVPMatrix, mPMatrix, mVMatrix, pickingMaterial);
+				mChildren.get(i).renderColorPicking(mCamera, pickingMaterial);
 			}
 		}
 


### PR DESCRIPTION
* Scene.java:
  * moving glClearDepth() prior to glClear()!
* Object3D.java:
  * eliminating unused parameters from renderColorPicking() signature
  * Comment clean-ups
* ObjectColorPicker.java:
  * Improving thread safety of mObjectLookup list
  * Filtering out requests when there is no listener
  * Skipping picking if there is no listener, and avoiding conflicts with setOnObjectPickedListener()...
  * Guarding against holes in the index due to unregistered objects and so returning null in onObjectPicked()