### PR TITLE
added an unknown NDK location error message.

### DIFF
--- a/vuforia/build.gradle
+++ b/vuforia/build.gradle
@@ -71,6 +71,9 @@ dependencies {
 File getNdkBuildFile() {
     String name = Os.isFamily(Os.FAMILY_WINDOWS) ? 'ndk-build.cmd' : 'ndk-build'
     File ndkDir = android.getNdkDirectory()
+    if(ndkDir == null) throw new GradleException('NDK location not found. '
+                          + 'Define location with ndk.dir in the local.properties file '
+                          + 'or with an ANDROID_NDK_HOME environment variable.')
     return new File(ndkDir, name)
 }
 


### PR DESCRIPTION
Implemented the second part of of issue 1663, added an error message if NDK is not found.
Do not know the vuforia build components well enough to risk messing with that.