### PR TITLE
Working version of FXAA pass.

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/data/DataSet.java
+++ b/examples/src/main/java/org/rajawali3d/examples/data/DataSet.java
@@ -59,6 +59,7 @@ import org.rajawali3d.examples.examples.optimizations.Optimized2000PlanesFragmen
 import org.rajawali3d.examples.examples.optimizations.TextureAtlasFragment;
 import org.rajawali3d.examples.examples.optimizations.UpdateVertexBufferFragment;
 import org.rajawali3d.examples.examples.postprocessing.BloomEffectFragment;
+import org.rajawali3d.examples.examples.postprocessing.FXAAFragment;
 import org.rajawali3d.examples.examples.postprocessing.FogFragment;
 import org.rajawali3d.examples.examples.postprocessing.GaussianBlurFilterFragment;
 import org.rajawali3d.examples.examples.postprocessing.GreyScaleFilterFragment;
@@ -80,16 +81,16 @@ import java.util.LinkedList;
 import java.util.List;
 
 public final class DataSet {
-    
+
     private static volatile DataSet instance;
-    
+
     private final List<Category> categories;
-    
+
     DataSet() {
         categories = createCategories();
         categories.addAll(DataSetImpl.getInstance().getCategories());
     }
-    
+
     public static synchronized DataSet getInstance() {
         if (instance == null) {
             synchronized (DataSet.class) {
@@ -98,7 +99,7 @@ public final class DataSet {
                 }
             }
         }
-        
+
         return instance;
     }
 
@@ -192,6 +193,7 @@ public final class DataSet {
                 new Example(R.string.example_post_processing_render_to_texture, RenderToTextureFragment.class),
                 new Example(R.string.example_post_processing_bloom_effect, BloomEffectFragment.class),
                 new Example(R.string.example_post_processing_shadow_mapping, ShadowMappingFragment.class),
+                new Example(R.string.example_post_processing_fxaa, FXAAFragment.class),
         }));
         categories.add(new Category(R.string.category_scenes, new Example[]{
                 new Example(R.string.example_scene_frame_callbacks, SceneFrameCallbackFragment.class),
@@ -204,5 +206,5 @@ public final class DataSet {
     public List<Category> getCategories() {
         return categories;
     }
-    
+
 }

--- a/examples/src/main/java/org/rajawali3d/examples/examples/animation/SkeletalAnimationBlendingFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/animation/SkeletalAnimationBlendingFragment.java
@@ -3,14 +3,11 @@ package org.rajawali3d.examples.examples.animation;
 import android.content.Context;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.LinearLayout;
-import android.widget.TextView;
 import org.rajawali3d.animation.mesh.SkeletalAnimationObject3D;
 import org.rajawali3d.animation.mesh.SkeletalAnimationSequence;
 import org.rajawali3d.examples.R;
@@ -25,29 +22,22 @@ public class SkeletalAnimationBlendingFragment extends AExampleFragment implemen
     @Override
     public View onCreateView(LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        LinearLayout ll = (LinearLayout) inflater.inflate(R.layout.skeletal_blending_button_bar, mLayout, true);
+        super.onCreateView(inflater, container, savedInstanceState);
+        inflater.inflate(R.layout.skeletal_blending_button_bar, mLayout, true);
 
-        Button button1 = (Button) ll.findViewById(R.id.button1);
+        Button button1 = (Button) mLayout.findViewById(R.id.button1);
         button1.setOnClickListener(this);
 
-        Button button2 = (Button) ll.findViewById(R.id.button2);
+        Button button2 = (Button) mLayout.findViewById(R.id.button2);
         button2.setOnClickListener(this);
 
-        Button button3 = (Button) ll.findViewById(R.id.button3);
+        Button button3 = (Button) mLayout.findViewById(R.id.button3);
         button3.setOnClickListener(this);
 
-        Button button4 = (Button) ll.findViewById(R.id.button4);
+        Button button4 = (Button) mLayout.findViewById(R.id.button4);
         button4.setOnClickListener(this);
 
-        ll = new LinearLayout(getActivity());
-        ll.setOrientation(LinearLayout.HORIZONTAL);
-        ll.setGravity(Gravity.TOP);
-
-        TextView creatorText = new TextView(getActivity());
-        creatorText.setText(R.string.skeletal_animation_blending_button_arm_stretch);
-        ll.addView(creatorText);
-
-        mLayout.addView(ll);
+        inflater.inflate(R.layout.skeletal_blending_creator_bar, mLayout, true);
 
         return mLayout;
     }

--- a/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/FXAAFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/FXAAFragment.java
@@ -1,0 +1,125 @@
+package org.rajawali3d.examples.examples.postprocessing;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.view.ViewGroup;
+import android.widget.Button;
+import org.rajawali3d.Object3D;
+import org.rajawali3d.animation.Animation;
+import org.rajawali3d.animation.Animation3D;
+import org.rajawali3d.animation.RotateOnAxisAnimation;
+import org.rajawali3d.examples.R;
+import org.rajawali3d.examples.examples.AExampleFragment;
+import org.rajawali3d.loader.LoaderAWD;
+import org.rajawali3d.math.vector.Vector3;
+import org.rajawali3d.postprocessing.PostProcessingManager;
+import org.rajawali3d.postprocessing.passes.FXAAPass;
+import org.rajawali3d.postprocessing.passes.RenderPass;
+
+public class FXAAFragment extends AExampleFragment {
+
+    boolean fxaaEnabled = true;
+
+	@Override
+    public AExampleRenderer createRenderer() {
+		return new FXAARenderer(getActivity(), this);
+	}
+
+    @Override
+    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+        super.onCreateView(inflater, container, savedInstanceState);
+
+        super.onCreateView(inflater, container, savedInstanceState);
+        inflater.inflate(R.layout.fxaa_button_bar, mLayout, true);
+
+        final Button button = (Button) mLayout.findViewById(R.id.button1);
+        button.setText(R.string.fxaa_fragment_button_disable_fxaa);
+        button.setTextSize(20);
+        button.setGravity(Gravity.CENTER);
+        button.setHeight(100);
+        button.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                fxaaEnabled = !fxaaEnabled;
+                if (fxaaEnabled) {
+                    ((FXAARenderer) mRenderer).enableFXAA();
+                    button.setText(R.string.fxaa_fragment_button_disable_fxaa);
+                } else {
+                    ((FXAARenderer) mRenderer).disableFXAA();
+                    button.setText(R.string.fxaa_fragment_button_enable_fxaa);
+                }
+            }
+        });
+
+        return mLayout;
+    }
+
+    private final class FXAARenderer extends AExampleRenderer {
+		private PostProcessingManager mEffects;
+        private RenderPass mRenderPass;
+        private FXAAPass mFXAAPass;
+
+		public FXAARenderer(Context context, @Nullable AExampleFragment fragment) {
+			super(context, fragment);
+		}
+
+		@Override
+		protected void initScene() {
+			try {
+				final LoaderAWD parser = new LoaderAWD(mContext.getResources(), mTextureManager, R.raw.awd_arrows);
+				parser.parse();
+
+				final Object3D obj = parser.getParsedObject();
+
+				obj.setScale(0.25f);
+				getCurrentScene().addChild(obj);
+
+				final Animation3D anim = new RotateOnAxisAnimation(Vector3.Axis.Y, -360);
+				anim.setDurationDelta(4d);
+				anim.setRepeatMode(Animation.RepeatMode.INFINITE);
+				anim.setTransformable3D(obj);
+				//anim.play();
+				//getCurrentScene().registerAnimation(anim);
+
+				//
+				// -- Create a post processing manager. We can add multiple passes to this.
+				//
+
+				mEffects = new PostProcessingManager(this);
+				mRenderPass = new RenderPass(getCurrentScene(), getCurrentCamera(), 0);
+				mEffects.addPass(mRenderPass);
+
+                mFXAAPass = new FXAAPass();
+                mFXAAPass.setRenderToScreen(true);
+                mEffects.addPass(mFXAAPass);
+
+			} catch (Exception e) {
+				e.printStackTrace();
+			}
+
+		}
+
+        @Override
+        public void onRender(final long ellapsedTime, final double deltaTime) {
+            mEffects.render(ellapsedTime, deltaTime);
+        }
+
+        public void enableFXAA() {
+            mRenderPass.setRenderToScreen(false);
+            mFXAAPass.setRenderToScreen(true);
+            mEffects.addPass(mFXAAPass);
+        }
+
+        public void disableFXAA() {
+            mEffects.removePass(mFXAAPass);
+            mFXAAPass.setRenderToScreen(false);
+            mRenderPass.setRenderToScreen(true);
+        }
+	}
+
+}

--- a/examples/src/main/res/layout/fxaa_button_bar.xml
+++ b/examples/src/main/res/layout/fxaa_button_bar.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:orientation="horizontal"
+              android:gravity="bottom"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <Button
+        android:id="@+id/button1"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/fxaa_fragment_button_disable_fxaa"
+        tools:ignore="ButtonStyle"/>
+
+</LinearLayout>

--- a/examples/src/main/res/layout/skeletal_blending_creator_bar.xml
+++ b/examples/src/main/res/layout/skeletal_blending_creator_bar.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
+              android:orientation="horizontal"
+              android:gravity="bottom"
+              android:layout_width="match_parent"
+              android:layout_height="match_parent">
+
+    <TextView
+        android:text="@string/skeletal_animation_blending_button_arm_stretch"
+        android:gravity="top|start"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/examples/src/main/res/values/strings.xml
+++ b/examples/src/main/res/values/strings.xml
@@ -80,5 +80,8 @@
     <string name="add_cube">Add Cube</string>
     <string name="remove_cube">Remove Random Cube</string>
     <string name="example_scene_add_remove_objects">Add/Remove Children</string>
+    <string name="example_post_processing_fxaa">FXAA Anti Aliasing</string>
+    <string name="fxaa_fragment_button_disable_fxaa">Disable FXAA</string>
+    <string name="fxaa_fragment_button_enable_fxaa">Enable FXAA</string>
 
 </resources>

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/EffectPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/EffectPass.java
@@ -12,6 +12,7 @@
  */
 package org.rajawali3d.postprocessing.passes;
 
+import android.support.annotation.NonNull;
 import org.rajawali3d.materials.Material;
 import org.rajawali3d.materials.shaders.FragmentShader;
 import org.rajawali3d.materials.shaders.VertexShader;
@@ -48,13 +49,18 @@ public class EffectPass extends APass {
 		setMaterial(material);
 	}
 
-	protected void createMaterial(int vertexShaderResourceId, int fragmentShaderResourceId)
+	protected void createMaterial(@NonNull VertexShader vertexShader, @NonNull FragmentShader fragmentShader)
 	{
-		mVertexShader = new VertexShader(vertexShaderResourceId);
-		mFragmentShader = new FragmentShader(fragmentShaderResourceId);
+		mVertexShader = vertexShader;
+		mFragmentShader = fragmentShader;
 		mVertexShader.setNeedsBuild(false);
 		mFragmentShader.setNeedsBuild(false);
 		setMaterial(new Material(mVertexShader, mFragmentShader));
+	}
+
+	protected void createMaterial(int vertexShaderResourceId, int fragmentShaderResourceId)
+	{
+		createMaterial(new VertexShader(vertexShaderResourceId), new FragmentShader(fragmentShaderResourceId));
 	}
 
 

--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/FXAAPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/FXAAPass.java
@@ -1,0 +1,98 @@
+package org.rajawali3d.postprocessing.passes;
+
+import android.opengl.GLES30;
+import org.rajawali3d.R;
+import org.rajawali3d.materials.shaders.FragmentShader;
+import org.rajawali3d.materials.shaders.VertexShader;
+import org.rajawali3d.primitives.ScreenQuad;
+import org.rajawali3d.renderer.RenderTarget;
+import org.rajawali3d.renderer.Renderer;
+import org.rajawali3d.scene.Scene;
+
+/**
+ * Adds a Fast Approximate Antialiasing (FXAA) post processing pass to the scene. The implementation is taken from
+ * <a href="http://www.geeks3d.com/20110405/fxaa-fast-approximate-anti-aliasing-demo-glsl-opengl-test-radeon-geforce/">Geeks 3D</a>.
+ *
+ * <b>Use of this effect requires GL ES 3.0 or better.</b>.
+ * <b>Use of this effect requires the following extension GL_EXT_gpu_shader4</b>
+ *
+ * A quick synopsis from the above reference follows:
+ * <ul>
+ *     <li>GPU based MLAA implementation by Timothy Lottes (Nvidia)</li>
+ *     <li>Multiple quality options</li>
+ * </ul>
+ *
+ * Pros & Cons:
+ * <ul>
+ *     <li>Superb antialiased long edges</li>
+ *     <li>Smooth overall picture</li>
+ *     <li>Reasonably fast</li>
+ *     <li>Moving pictures do not benefit as much</li>
+ *     <li>"Blurry"</li>
+ * </ul>
+ * @author Jared Woolston (jwoolston@tenkiv.com)
+ */
+public class FXAAPass extends EffectPass {
+
+    private static final String TAG = "FXAAPass";
+
+    public FXAAPass() {
+        super();
+        createMaterial(new FXAAVertexShader(), new FXAAFragmentShader());
+    }
+
+    @Override
+    public void render(Scene scene, Renderer renderer, ScreenQuad screenQuad, RenderTarget writeTarget,
+                                 RenderTarget readTarget, long ellapsedTime, double deltaTime) {
+        //Log.d(TAG, "Rendering FXAA Pass at time: " + ellapsedTime);
+        super.render(scene, renderer, screenQuad, writeTarget, readTarget, ellapsedTime, deltaTime);
+    }
+
+    protected class FXAAVertexShader extends VertexShader {
+
+        private int rtWHandle;
+        private int rtHHandle;
+
+        public FXAAVertexShader() {
+            super(R.raw.fxaa_vertex_shader);
+        }
+
+        @Override
+        public void setLocations(int programHandle) {
+            super.setLocations(programHandle);
+            rtWHandle = getUniformLocation(programHandle, "rt_w");
+            rtHHandle = getUniformLocation(programHandle, "rt_h");
+        }
+
+        @Override
+        public void applyParams() {
+            super.applyParams();
+            GLES30.glUniform1f(rtWHandle, mReadTarget.getWidth());
+            GLES30.glUniform1f(rtHHandle, mReadTarget.getHeight());
+        }
+    }
+
+    protected class FXAAFragmentShader extends FragmentShader {
+
+        private int rtWHandle;
+        private int rtHHandle;
+
+        public FXAAFragmentShader() {
+            super(R.raw.fxaa_fragment_shader);
+        }
+
+        @Override
+        public void setLocations(int programHandle) {
+            super.setLocations(programHandle);
+            rtWHandle = getUniformLocation(programHandle, "rt_w");
+            rtHHandle = getUniformLocation(programHandle, "rt_h");
+        }
+
+        @Override
+        public void applyParams() {
+            super.applyParams();
+            GLES30.glUniform1f(rtWHandle, mReadTarget.getWidth());
+            GLES30.glUniform1f(rtHHandle, mReadTarget.getHeight());
+        }
+    }
+}

--- a/rajawali/src/main/java/org/rajawali3d/util/Capabilities.java
+++ b/rajawali/src/main/java/org/rajawali3d/util/Capabilities.java
@@ -15,6 +15,7 @@ package org.rajawali3d.util;
 import android.opengl.EGLExt;
 import android.opengl.GLES20;
 import android.os.Build;
+import android.support.annotation.NonNull;
 
 import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
@@ -54,6 +55,8 @@ public class Capabilities {
     private int mMaxAliasedPointSize;
 
     private int[] mParam;
+
+    private String[] mExtensions;
 
     private Capabilities() {
         initialize();
@@ -140,6 +143,9 @@ public class Capabilities {
         mMaxAliasedLineWidth = getInt(GLES20.GL_ALIASED_LINE_WIDTH_RANGE, 2, 1);
         mMinAliasedPointSize = getInt(GLES20.GL_ALIASED_POINT_SIZE_RANGE, 2, 0);
         mMaxAliasedPointSize = getInt(GLES20.GL_ALIASED_POINT_SIZE_RANGE, 2, 1);
+
+        String extensions = GLES20.glGetString(GLES20.GL_EXTENSIONS);
+        mExtensions = extensions.split(" ");
     }
 
     private int getInt(int pname) {
@@ -181,6 +187,30 @@ public class Capabilities {
     public static int getGLESMajorVersion() {
         if (!sGLChecked) checkGLVersion();
         return mGLESMajorVersion;
+    }
+
+    /**
+     * Fetch the list of extension strings this device supports.
+     *
+     * @return
+     */
+    public String[] getExtensions() {
+        return mExtensions;
+    }
+
+    /**
+     * Checks if a particular extension is supported by this device.
+     *
+     * @param extension {@link String} Non-null string of the extension to check for. This is case sensitive.
+     * @throws {@link UnsupportedCapabilityException} if the extension is not available.
+     */
+    public void verifyExtension(@NonNull String extension) throws UnsupportedCapabilityException {
+        for (String ext : mExtensions) {
+            if (extension.equals(ext)) {
+                return;
+            }
+        }
+        throw new UnsupportedCapabilityException("Extension (" + extension + ") is not supported!");
     }
 
     /**
@@ -352,5 +382,49 @@ public class Capabilities {
         sb.append("Max Aliased Point Width            : ").append(mMaxAliasedPointSize).append("\n");
         sb.append("-=-=-=- /OpenGL Capabilities -=-=-=-\n");
         return sb.toString();
+    }
+
+    public static class UnsupportedCapabilityException extends Exception {
+
+        /**
+         * Constructs a new {@code UnsupportedCapabilityException} that includes the current stack trace.
+         */
+        public UnsupportedCapabilityException() {
+        }
+
+        /**
+         * Constructs a new {@code UnsupportedCapabilityException} with the current stack trace and the
+         * specified detail message.
+         *
+         * @param detailMessage
+         *            the detail message for this exception.
+         */
+        public UnsupportedCapabilityException(String detailMessage) {
+            super(detailMessage);
+        }
+
+        /**
+         * Constructs a new {@code UnsupportedCapabilityException} with the current stack trace, the
+         * specified detail message and the specified cause.
+         *
+         * @param detailMessage
+         *            the detail message for this exception.
+         * @param throwable
+         *            the cause of this exception.
+         */
+        public UnsupportedCapabilityException(String detailMessage, Throwable throwable) {
+            super(detailMessage, throwable);
+        }
+
+        /**
+         * Constructs a new {@code UnsupportedCapabilityException} with the current stack trace and the
+         * specified cause.
+         *
+         * @param throwable
+         *            the cause of this exception.
+         */
+        public UnsupportedCapabilityException(Throwable throwable) {
+            super(throwable);
+        }
     }
 }

--- a/rajawali/src/main/java/org/rajawali3d/util/RajLog.java
+++ b/rajawali/src/main/java/org/rajawali3d/util/RajLog.java
@@ -85,9 +85,9 @@ public final class RajLog {
         int extLength = ext.length;
 
         if (extLength > 0) {
-            sb.append("Extensions : ").append(ext[0]).append("\n");
+            sb.append("Extensions : ").append('\n').append(ext[0]).append('\n');
             for (int i = 1; i < extLength; i++) {
-                sb.append(" : ").append(ext[i]).append("\n");
+                sb.append(" : ").append(ext[i]).append('\n');
             }
         }
         sb.append("-=-=-=- /OpenGL Information -=-=-=-\n");

--- a/rajawali/src/main/res/raw/fxaa_fragment_shader.glsl
+++ b/rajawali/src/main/res/raw/fxaa_fragment_shader.glsl
@@ -1,0 +1,76 @@
+precision highp float;
+
+#define FXAA_SPAN_MAX 8.0
+#define FXAA_REDUCE_MUL (1.0 / 8.0)
+#define FXAA_REDUCE_MIN (1.0 / 256.0)
+
+uniform sampler2D uTexture;
+
+uniform float rt_w;
+uniform float rt_h;
+
+varying vec4 posPos;
+varying vec2 vTextureCoord;
+
+#define FxaaTexOff(t, p, o, r) texture2D(t, p + (o * r))
+
+/**
+ *
+ * @param posPos {@link vec4} Output of FxaaVertexShader interpolated across screen.
+ * @param tex {@link sampler2D} The input texture.
+ * @param rcpFrame {@link vec2} Constant {1.0/frameWidth, 1.0/frameHeight}.
+ */
+vec3 FxaaPixelShader(vec4 posPos, sampler2D tex, vec2 rcpFrame) {
+/*---------------------------------------------------------*/
+    vec3 rgbNW = texture2D(tex, posPos.zw).xyz;
+    vec3 rgbNE = FxaaTexOff(tex, posPos.zw, vec2(1,0), rcpFrame.xy).xyz;
+    vec3 rgbSW = FxaaTexOff(tex, posPos.zw, vec2(0,1), rcpFrame.xy).xyz;
+    vec3 rgbSE = FxaaTexOff(tex, posPos.zw, vec2(1,1), rcpFrame.xy).xyz;
+    vec3 rgbM  = texture2D(tex, posPos.xy).xyz;
+/*---------------------------------------------------------*/
+    vec3 luma = vec3(0.299, 0.587, 0.114);
+    float lumaNW = dot(rgbNW, luma);
+    float lumaNE = dot(rgbNE, luma);
+    float lumaSW = dot(rgbSW, luma);
+    float lumaSE = dot(rgbSE, luma);
+    float lumaM  = dot(rgbM,  luma);
+/*---------------------------------------------------------*/
+    float lumaMin = min(lumaM, min(min(lumaNW, lumaNE), min(lumaSW, lumaSE)));
+    float lumaMax = max(lumaM, max(max(lumaNW, lumaNE), max(lumaSW, lumaSE)));
+/*---------------------------------------------------------*/
+    vec2 dir;
+    dir.x = -((lumaNW + lumaNE) - (lumaSW + lumaSE));
+    dir.y =  ((lumaNW + lumaSW) - (lumaNE + lumaSE));
+/*---------------------------------------------------------*/
+    float dirReduce = max((lumaNW + lumaNE + lumaSW + lumaSE) * (0.25 * FXAA_REDUCE_MUL), FXAA_REDUCE_MIN);
+    float rcpDirMin = 1.0 / (min(abs(dir.x), abs(dir.y)) + dirReduce);
+    dir = min(vec2( FXAA_SPAN_MAX,  FXAA_SPAN_MAX),
+          max(vec2(-FXAA_SPAN_MAX, -FXAA_SPAN_MAX),
+          dir * rcpDirMin)) * rcpFrame.xy;
+/*--------------------------------------------------------*/
+    vec3 rgbA = (1.0 / 2.0) * (
+        texture2D(tex, posPos.xy + dir * (1.0 / 3.0 - 0.5)).xyz +
+        texture2D(tex, posPos.xy + dir * (2.0 / 3.0 - 0.5)).xyz);
+    vec3 rgbB = rgbA * (1.0 / 2.0) + (1.0 / 4.0) * (
+        texture2D(tex, posPos.xy + dir * (0.0 / 3.0 - 0.5)).xyz +
+        texture2D(tex, posPos.xy + dir * (3.0 / 3.0 - 0.5)).xyz);
+    float lumaB = dot(rgbB, luma);
+    if((lumaB < lumaMin) || (lumaB > lumaMax)) {
+        return rgbA;
+    }
+    return rgbB;
+}
+
+vec4 PostFX(sampler2D tex, vec2 uv, float time) {
+  vec4 c = vec4(0.0);
+  vec2 rcpFrame = vec2(1.0 / rt_w, 1.0 / rt_h);
+  c.rgb = FxaaPixelShader(posPos, tex, rcpFrame);
+  //c.rgb = 1.0 - texture2D(tex, posPos.xy).rgb;
+  c.a = 1.0;
+  return c;
+}
+
+void main() {
+  vec2 uv = vTextureCoord.st;
+  gl_FragColor = PostFX(uTexture, uv, 0.0);
+}

--- a/rajawali/src/main/res/raw/fxaa_vertex_shader.glsl
+++ b/rajawali/src/main/res/raw/fxaa_vertex_shader.glsl
@@ -1,0 +1,21 @@
+precision highp float;
+
+const float FXAA_SUBPIX_SHIFT = 1.0 / 8.0;
+
+uniform mat4 uMVPMatrix;
+uniform float rt_w;
+uniform float rt_h;
+
+attribute vec4 aPosition;
+attribute vec2 aTextureCoord;
+
+varying vec4 posPos;
+varying vec2 vTextureCoord;
+
+void main(void) {
+    gl_Position = uMVPMatrix * aPosition;
+    vTextureCoord = aTextureCoord;
+    vec2 rcpFrame = vec2(1.0 / rt_w, 1.0 / rt_h);
+    posPos.xy = aTextureCoord.xy;
+    posPos.zw = aTextureCoord.xy - (rcpFrame * (0.5 + FXAA_SUBPIX_SHIFT));
+}


### PR DESCRIPTION
Inspired by #1721 

Adds Fast Approximate Anti-Aliasing (FXAA) post processing pass and example compatible with all API levels. This is a basic initial implementation. I have plans on working on adding "tuning" options to the shader as well as some efficiency changes. The included example shows a good best and worst case scenario with respect to FXAAs shortcomings to vertical/horizontal edges and strengths with long diagonal edges. 

FXAA Off
![fxaa_off](https://cloud.githubusercontent.com/assets/2993125/17838991/06858f64-6790-11e6-992a-36635e9b8ace.png)

FXAA On
![fxaa_on](https://cloud.githubusercontent.com/assets/2993125/17838993/0def5bf4-6790-11e6-83cc-56e2ff370131.png)

