### PR TITLE
Fixes #1718 

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/scene/ObjectAddRemoveFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/scene/ObjectAddRemoveFragment.java
@@ -11,6 +11,7 @@ import android.widget.Button;
 import android.widget.FrameLayout;
 import android.widget.ProgressBar;
 
+import org.rajawali3d.Object3D;
 import org.rajawali3d.animation.Animation;
 import org.rajawali3d.animation.RotateOnAxisAnimation;
 import org.rajawali3d.examples.R;
@@ -127,7 +128,9 @@ public class ObjectAddRemoveFragment extends AExampleFragment {
             final int count = getCurrentScene().getNumChildren();
             if (count > 0) {
                 final int index = random.nextInt(count);
-                getCurrentScene().removeChild(getCurrentScene().getChildrenCopy().get(index));
+                final Object3D child = getCurrentScene().getChildrenCopy().get(index);
+                getCurrentScene().removeChild(child);
+                child.destroy();
             }
         }
     }

--- a/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
@@ -960,10 +960,6 @@ public class Geometry3D {
         }
         GLES20.glDeleteBuffers(buffers.length, buffers, 0);
 
-        if (mOriginalGeometry != null) {
-            mOriginalGeometry.destroy();
-        }
-
         mOriginalGeometry = null;
 
         mBuffers.clear();

--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -850,10 +850,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 
 	public void destroy() {
         mIsDestroyed = true;
-		if (mGeometry != null)
 			mGeometry.destroy();
-		if (mMaterial != null)
-			MaterialManager.getInstance().removeMaterial(mMaterial);
 		mMaterial = null;
 		mGeometry = null;
 		for (int i = 0, j = mChildren.size(); i < j; i++)


### PR DESCRIPTION
Following the logic of #1610, this removes the automatic material removal when calling Object3D#destroy(). Additionally, prevents Geometry3D#destroy() from destroying any parent geometry which may still be in use by other objects.

Signed-off-by: Jared Woolston <jwoolston@tenkiv.com>