### PR TITLE
Do not remove item from array to maintain the consistency with the index

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/util/ObjectColorPicker.java
+++ b/rajawali/src/main/java/org/rajawali3d/util/ObjectColorPicker.java
@@ -72,7 +72,8 @@ public class ObjectColorPicker implements IObjectPicker {
 
 	public void unregisterObject(Object3D object) {
 		if (mObjectLookup.contains(object)) {
-			mObjectLookup.remove(object);
+			int index = mObjectLookup.indexOf(object);
+			mObjectLookup.set(index,null);
 		}
 		object.setPickingColor(Object3D.UNPICKABLE);
 	}


### PR DESCRIPTION
When calling unregisterObject  the index doesn't change but now the size of the object lookup array is smaller and it might happen that some objects are no longer clickable or return the wrong one so instead of removing the item from the array we can just set the value to null.