### PR TITLE
Get the first empty in the loader threads SparseArray and use it as ID for the new thread.

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
@@ -56,6 +56,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.microedition.khronos.egl.EGL10;
 import javax.microedition.khronos.egl.EGLConfig;
@@ -122,6 +123,11 @@ public abstract class Renderer implements ISurfaceRenderer {
     private final Object mNextSceneLock = new Object(); //Scene switching lock
 
     private long mRenderStartTime;
+
+    /**
+     * Keep track of IDs in {@link Renderer#mLoaderThreads}
+     */
+    private AtomicInteger mLastLoaderId = new AtomicInteger();
 
     private final boolean mHaveRegisteredForResources;
 
@@ -549,13 +555,7 @@ public abstract class Renderer implements ISurfaceRenderer {
         loader.setTag(tag);
 
         try {
-            int id=0;
-            ModelRunnable thread = mLoaderThreads.get(id);
-            while(thread != null){
-                id++;
-                thread = mLoaderThreads.get(id);
-            }
-            
+            final int id = mLastLoaderId.getAndIncrement();
             final ModelRunnable runnable = new ModelRunnable(loader, id);
 
             mLoaderThreads.put(id, runnable);

--- a/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
@@ -549,7 +549,13 @@ public abstract class Renderer implements ISurfaceRenderer {
         loader.setTag(tag);
 
         try {
-            final int id = mLoaderThreads.size();
+            int id=0;
+            ModelRunnable thread = mLoaderThreads.get(id);
+            while(thread != null){
+                id++;
+                thread = mLoaderThreads.get(id);
+            }
+            
             final ModelRunnable runnable = new ModelRunnable(loader, id);
 
             mLoaderThreads.put(id, runnable);


### PR DESCRIPTION
For the loading new models asynchronously the id of the new thread is just the size of the SparseArray at the moment, the id is then used to retrieve the the thread at the end of the execution but if other threads finished before they might influence the array leading to a NullPointerException when trying to retrieve the thread.

A more simple solution could be to have the last ID as a member but I wouldn't want to run into max int complications if there are A LOT of models loaded constantly and it shouldn't affect performance.