### PR TITLE
Enable parent objects with no vertices to create Bounding Box

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
@@ -1074,4 +1074,8 @@ public class Geometry3D {
     public void setBuffersCreated(boolean created) {
         mHaveCreatedBuffers = created;
     }
+
+    void setBoundingBox(BoundingBox boundingBox){
+        this.mBoundingBox = boundingBox;
+    }
 }

--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -348,30 +348,44 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 		}
 	}
 
+	/**
+	 * Returns a {@link BoundingBox} for this Object3D and creates it if needed.
+	 * Utilizes children's bounding values to calculate its own {@link BoundingBox}.
+	 * @return
+     */
 	public BoundingBox getBoundingBox() {
 		if (getNumChildren() > 0 && !mGeometry.hasBoundingBox()) {
 			Vector3 min = new Vector3(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
 			Vector3 max = new Vector3(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE);
 
-			for (int i = 0; i < getNumChildren(); i++) {
+ 			for (int i = 0; i < getNumChildren(); i++) {
 				Object3D child = getChildAt(i);
-				Vector3 maxVertex = child.getBoundingBox().getMax();
+				updateMaxMinCoords(min, max, child);
+			}
 
-				if (maxVertex.x > max.x) max.x = maxVertex.x;
-				if (maxVertex.y > max.y) max.y = maxVertex.y;
-				if (maxVertex.z > max.z) max.z = maxVertex.z;
-
-				Vector3 minVertex = child.getBoundingBox().getMin();
-
-				if (minVertex.x < min.x) min.x = minVertex.x;
-				if (minVertex.y < min.y) min.y = minVertex.y;
-				if (minVertex.z < min.z) min.z = minVertex.z;
+			if (mGeometry.getVertices() != null) {
+				updateMaxMinCoords(min, max, this);
 			}
 
 			mGeometry.setBoundingBox(new BoundingBox(min, max));
 		}
 		return mGeometry.getBoundingBox();
 	}
+
+	private void updateMaxMinCoords(Vector3 min, Vector3 max, Object3D child) {
+		Vector3 maxVertex = child.getBoundingBox().getMax();
+
+		if (maxVertex.x > max.x) max.x = maxVertex.x;
+		if (maxVertex.y > max.y) max.y = maxVertex.y;
+		if (maxVertex.z > max.z) max.z = maxVertex.z;
+
+		Vector3 minVertex = child.getBoundingBox().getMin();
+
+		if (minVertex.x < min.x) min.x = minVertex.x;
+		if (minVertex.y < min.y) min.y = minVertex.y;
+		if (minVertex.z < min.z) min.z = minVertex.z;
+	}
+
 
 	/**
 	 * Renders the object for color-picking

--- a/rajawali/src/main/java/org/rajawali3d/bounds/BoundingBox.java
+++ b/rajawali/src/main/java/org/rajawali3d/bounds/BoundingBox.java
@@ -137,31 +137,47 @@ public class BoundingBox implements IBoundingVolume {
 	public int getBoundingColor() {
 		return mBoundingColor.get();
 	}
-	
-	public void calculateBounds(Geometry3D geometry) {
-		FloatBuffer vertices = geometry.getVertices();
-		vertices.rewind();
-		
-		mMin.setAll(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
-		mMax.setAll(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE);
-		
-		Vector3 vertex = new Vector3();
-		
-		while (vertices.hasRemaining()) {
-			vertex.x = vertices.get();
-			vertex.y = vertices.get();
-			vertex.z = vertices.get();
-			
-			if(vertex.x < mMin.x) mMin.x = vertex.x;
-			if(vertex.y < mMin.y) mMin.y = vertex.y;
-			if(vertex.z < mMin.z) mMin.z = vertex.z;
-			if(vertex.x > mMax.x) mMax.x = vertex.x;
-			if(vertex.y > mMax.y) mMax.y = vertex.y;
-			if(vertex.z > mMax.z) mMax.z = vertex.z;
-		}
-		calculatePoints();
-	}
-	
+
+    public void calculateBounds(Geometry3D geometry) {
+        mMin.setAll(Double.MAX_VALUE, Double.MAX_VALUE, Double.MAX_VALUE);
+        mMax.setAll(-Double.MAX_VALUE, -Double.MAX_VALUE, -Double.MAX_VALUE);
+
+        FloatBuffer vertices = geometry.getVertices();
+        if(vertices != null){
+            calculateMinMaxVertices(vertices, mMin, mMax);
+            calculatePoints();
+        }
+
+    }
+
+    /**
+     * Traverses the vertices, to find the minimum and maximum x,y,z coordinates.
+     * If the vertices are null, the mMin and mMax remain un affected
+     *
+     * @param vertices can be null
+     * @param mMin mutable vertex that contains a point, will get updated to the minimum coordinate
+     *             of given vertices
+     * @param mMax mutable vertex that contains a point, will get updated to the maximum coordinate
+     *             of given vertices
+     */
+    private void calculateMinMaxVertices(FloatBuffer vertices, Vector3 mMin, Vector3 mMax) {
+        if(vertices == null) return;
+        vertices.rewind();
+        Vector3 vertex = new Vector3();
+
+        while (vertices.hasRemaining()) {
+            vertex.x = vertices.get();
+            vertex.y = vertices.get();
+            vertex.z = vertices.get();
+
+            if (vertex.x < mMin.x) mMin.x = vertex.x;
+            if (vertex.y < mMin.y) mMin.y = vertex.y;
+            if (vertex.z < mMin.z) mMin.z = vertex.z;
+            if (vertex.x > mMax.x) mMax.x = vertex.x;
+            if (vertex.y > mMax.y) mMax.y = vertex.y;
+            if (vertex.z > mMax.z) mMax.z = vertex.z;
+        }
+    }
 	public void calculatePoints() {
 		// -- bottom plane
 		// -- -x, -y, -z

--- a/rajawali/src/main/java/org/rajawali3d/bounds/BoundingBox.java
+++ b/rajawali/src/main/java/org/rajawali3d/bounds/BoundingBox.java
@@ -40,6 +40,13 @@ public class BoundingBox implements IBoundingVolume {
 	public BoundingBox() {
 		this(new Vector3[8]);
 	}
+
+	public BoundingBox(Vector3 min, Vector3 max) {
+		this();
+		mMin.setAll(min.x, min.y, min.z);
+		mMax.setAll(max.x, max.y, max.z);
+		calculatePoints();
+	}
 	
 	public BoundingBox(Vector3[] points) {
 		mTransformedMin = new Vector3();


### PR DESCRIPTION
Fix for issue #1774 

Opened pull request to get some guidance. For now only refactored code that search for min max points in Object3D's vertices.