### PR TITLE
Addressing issue #1784:

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/ATransformable3D.java
@@ -924,6 +924,15 @@ public abstract class ATransformable3D implements IGraphNodeMember {
         return mScale.z;
     }
 
+    /**
+     * Check whether the scaling factor is zero on all three axes
+     *
+     * @return true if all three factors are zero
+     */
+    public boolean isZeroScale() {
+        return (mScale.x == 0d) && (mScale.y == 0d) && (mScale.z == 0d);
+    }
+
 
 
     //--------------------------------------------------

--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -196,7 +196,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 	 */
 	public void render(Camera camera, final Matrix4 vpMatrix, final Matrix4 projMatrix, final Matrix4 vMatrix,
 			final Matrix4 parentMatrix, Material sceneMaterial) {
-		if (isDestroyed() || (!mIsVisible && !mRenderChildrenAsBatch)) {
+		if (isDestroyed() || (!mIsVisible && !mRenderChildrenAsBatch) || isZeroScale()) {
             return;
         }
 
@@ -355,7 +355,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 	 * @param pickingMaterial The color-picking Material
 	 */
 	public void renderColorPicking(final Camera camera, final Material pickingMaterial) {
-		if (!mIsVisible && !mRenderChildrenAsBatch)
+		if (isDestroyed() || (!mIsVisible && !mRenderChildrenAsBatch) || isZeroScale())
 			// Neither the object nor any of its children are visible
 			return;
 

--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -15,6 +15,7 @@ package org.rajawali3d.materials;
 import android.graphics.Color;
 import android.opengl.GLES20;
 import android.support.annotation.NonNull;
+import android.util.Log;
 import org.rajawali3d.BufferInfo;
 import org.rajawali3d.Object3D;
 import org.rajawali3d.lights.ALight;
@@ -1077,7 +1078,7 @@ public class Material {
         try {
             mNormalMatrix.setToNormalMatrix();
         } catch (IllegalStateException exception) {
-            // modelMatrix is degenerate (zero scale)
+            RajLog.d("modelMatrix is degenerate (zero scale)...");
         }
         float[] matrix = mNormalMatrix.getFloatValues();
 

--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -1073,7 +1073,12 @@ public class Material {
         mModelMatrix = modelMatrix;//.getFloatValues();
         mVertexShader.setModelMatrix(mModelMatrix);
 
-        mNormalMatrix.setAll(modelMatrix).setToNormalMatrix();
+        mNormalMatrix.setAll(modelMatrix);
+        try {
+            mNormalMatrix.setToNormalMatrix();
+        } catch (IllegalStateException exception) {
+            // modelMatrix is degenerate (zero scale)
+        }
         float[] matrix = mNormalMatrix.getFloatValues();
 
         mNormalFloats[0] = matrix[0];

--- a/rajawali/src/main/java/org/rajawali3d/math/Matrix4.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/Matrix4.java
@@ -339,7 +339,7 @@ public final class Matrix4 implements Cloneable {
      *
      * @return A reference to this {@link Matrix4} to facilitate chaining.
      *
-     * @throws IllegalStateException if this matrix is singular and cannot be in
+     * @throws IllegalStateException if this matrix is singular and cannot be inverted
      */
     @NonNull
     public Matrix4 inverse() throws IllegalStateException {
@@ -717,9 +717,11 @@ public final class Matrix4 implements Cloneable {
      * Removes the translational component, inverts and transposes the matrix.
      *
      * @return A reference to this {@link Matrix4} to facilitate chaining.
+     *
+     * @throws IllegalStateException if this matrix is singular and cannot be inverted
      */
     @NonNull
-    public Matrix4 setToNormalMatrix() {
+    public Matrix4 setToNormalMatrix() throws IllegalStateException {
         m[M03] = 0;
         m[M13] = 0;
         m[M23] = 0;


### PR DESCRIPTION
- adding throws IllegalStateException to Matrix4.setToNormal() as it depends on Matrix4.inverse()
- putting call to setToNormal() in Material.setModelMatrix() in try/catch block, thus enabling continued rendering of degenerate/zero-scale Object3Ds (which have singular model matrices)

Tested on existing app where issue surfaced, no changes required.