### PR TITLE
Fix for issue #1796 unexpected behaviour from Vignette Pass

### DIFF
--- a/rajawali/src/main/res/raw/vignette_fragment_shader.glsl
+++ b/rajawali/src/main/res/raw/vignette_fragment_shader.glsl
@@ -20,8 +20,16 @@ void main() {
     //determine the vector length of the center position
     float len = length(position);
 
+    // derive inner and outer radii from uRadius and uSoftness
+    float inner = (uRadius > abs(uSoftness/2.)) ? uRadius - abs(uSoftness/2.) : 0.;
+    float outer = uRadius + abs(uSoftness/2.);
+    if(inner == outer) {
+      inner -= 0.00001;
+      outer += 0.00001;
+    }
+
     //use smoothstep to create a smooth vignette
-    float vignette = smoothstep(uRadius, uSoftness, len);
+    float vignette = 1. - smoothstep(inner, outer, len);
 
     //apply the vignette with 60% opacity
     texColor.rgb = mix(texColor.rgb, texColor.rgb * vignette, uOpacity);


### PR DESCRIPTION
Inner and Outer radii are now correctly derived from uRadius and uSmoothness.

Turns out that when vignette pass worked, it was due to undefined behaviour of smoothstep.
(smoothstep results are undefined if edge0 ≥ edge1)