### PR TITLE
Set back texture buffer position to zero

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
@@ -843,10 +843,10 @@ public class Geometry3D {
                     .allocateDirect(textureCoords.length * FLOAT_SIZE_BYTES)
                     .order(ByteOrder.nativeOrder()).asFloatBuffer();
             ((FloatBuffer) textureInfo.buffer).put(textureCoords);
-            textureInfo.buffer.position(0);
         } else {
             ((FloatBuffer) textureInfo.buffer).put(textureCoords);
         }
+        textureInfo.buffer.position(0);
         mHasTextureCoordinates = true;
     }
 


### PR DESCRIPTION
Otherwise if we call setTextureCoords() twice consecutively will cause a `BufferOverflowException`.