### PR TITLE
Fix set surface ilegal state exception

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/StreamingTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/StreamingTexture.java
@@ -19,6 +19,8 @@ import android.opengl.GLES11Ext;
 import android.opengl.GLES20;
 import android.view.Surface;
 
+import org.rajawali3d.util.RajLog;
+
 import java.io.IOException;
 
 public class StreamingTexture extends ATexture {
@@ -80,7 +82,11 @@ public class StreamingTexture extends ATexture {
         mSurfaceTexture = new SurfaceTexture(textureId);
         if (mMediaPlayer != null) {
             mSurface = new Surface(mSurfaceTexture);
-            mMediaPlayer.setSurface(mSurface);
+            try {
+                mMediaPlayer.setSurface(mSurface);
+            } catch (IllegalStateException e) {
+                RajLog.i("MediaPlayer setSurface failed.");
+            }
         } else if (mCamera != null) {
             try {
                 mSurfaceTexture.setOnFrameAvailableListener(mOnFrameAvailableListener);


### PR DESCRIPTION
I am using this library and I am getting multiple times the following crash:

```
Fatal Exception: java.lang.IllegalStateException
       at android.media.MediaPlayer._setVideoSurface(MediaPlayer.java)
       at android.media.MediaPlayer.setSurface(MediaPlayer.java:760)
       at org.rajawali3d.materials.textures.StreamingTexture.add(StreamingTexture.java:83)
       at org.rajawali3d.materials.textures.TextureManager.taskAdd(TextureManager.java:112)
       at org.rajawali3d.materials.textures.TextureManager.taskReload(TextureManager.java:211)
       at org.rajawali3d.renderer.Renderer.initScene(Renderer.java:366)
       at com.sandro.aerial.RendererActivity.onRenderSurfaceSizeChanged(RendererActivity.java:206)
       at org.rajawali3d.view.SurfaceView$RendererDelegate.onSurfaceChanged(SurfaceView.java:232)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1564)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1267)
```

This PR should fix the issue and it should be the appropriated solution since our callback that calls setSurface gets hit multiple times throughout the setup of playback, by the time start is called, the surface has been set again without throwing the exception.