### PR TITLE
Fix Array index out of bounds exception in TextureManager

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/TextureManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/TextureManager.java
@@ -13,6 +13,7 @@
 package org.rajawali3d.materials.textures;
 
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -200,13 +201,12 @@ public final class TextureManager extends AResourceManager {
 	 * {@link Renderer}.
 	 */
 	public void taskReload() {
-		int len = mTextureList.size();
-		for (int i = 0; i < len; i++) {
-			ATexture texture = mTextureList.get(i);
+		Iterator<ATexture> iterator = mTextureList.iterator();
+
+		while (iterator.hasNext()) {
+			ATexture texture = iterator.next();
 			if (texture.willRecycle()) {
-				mTextureList.remove(i);
-				i -= 1;
-				len -= 1;
+				iterator.remove();
 			} else {
 				taskAdd(texture, true);
 			}


### PR DESCRIPTION
I am using this library and I am facing the following issue:
```
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=3; index=3
       at java.util.concurrent.CopyOnWriteArrayList.get(CopyOnWriteArrayList.java:117)
       at java.util.Collections$SynchronizedList.get(Collections.java:537)
       at org.rajawali3d.materials.textures.TextureManager.taskReload(TextureManager.java:205)
       at org.rajawali3d.renderer.Renderer.initScene(Renderer.java:366)
       at com.sandro.aerial.RendererActivity.onRenderSurfaceSizeChanged(RendererActivity.java:206)
       at org.rajawali3d.view.SurfaceView$RendererDelegate.onSurfaceChanged(SurfaceView.java:232)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1550)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1278)
```

I believe that with this PR the issue could be fixed and using the iterator could also increase the method performance.