### PR TITLE
Fix crash loading a shader with empty source

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -15,6 +15,7 @@ package org.rajawali3d.materials;
 import android.graphics.Color;
 import android.opengl.GLES20;
 import android.support.annotation.NonNull;
+import android.text.TextUtils;
 import android.util.Log;
 import org.rajawali3d.BufferInfo;
 import org.rajawali3d.Object3D;
@@ -754,7 +755,7 @@ public class Material {
      */
     private int loadShader(int shaderType, String source) {
         int shader = GLES20.glCreateShader(shaderType);
-        if (shader != 0) {
+        if (shader != 0 && !TextUtils.isEmpty(source)) {
             GLES20.glShaderSource(shader, source);
             GLES20.glCompileShader(shader);
             int[] compiled = new int[1];


### PR DESCRIPTION
I am using this library and I am facing the following issue:
```
Fatal Exception: java.lang.IllegalArgumentException: string == null
       at android.opengl.GLES20.glShaderSource(GLES20.java)
       at org.rajawali3d.materials.Material.loadShader(Material.java:758)
       at org.rajawali3d.materials.Material.createProgram(Material.java:783)
       at org.rajawali3d.materials.Material.createShaders(Material.java:703)
       at org.rajawali3d.materials.Material.reload(Material.java:491)
       at org.rajawali3d.materials.MaterialManager.taskReload(MaterialManager.java:72)
       at org.rajawali3d.renderer.Renderer.initScene(Renderer.java:367)
       at com.sandro.aerial.RendererActivity.onRenderSurfaceSizeChanged(RendererActivity.java:206)
       at org.rajawali3d.view.SurfaceView$RendererDelegate.onSurfaceChanged(SurfaceView.java:232)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1537)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1253)
```

I believe that this PR can fix this issue.