### PR TITLE
Fix out of bounds exception in material manager

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/MaterialManager.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/MaterialManager.java
@@ -65,10 +65,7 @@ public class MaterialManager extends AResourceManager {
 	}
 
 	public void taskReload() {
-		int len = mMaterialList.size();
-		for (int i = 0; i < len; i++)
-		{
-			Material material = mMaterialList.get(i);
+		for(Material material: mMaterialList) {
 			material.reload();
 		}
 	}


### PR DESCRIPTION
I am using this library and I am facing the following issue:
```
Fatal Exception: java.lang.ArrayIndexOutOfBoundsException: length=1; index=1
       at java.util.concurrent.CopyOnWriteArrayList.get(CopyOnWriteArrayList.java:117)
       at java.util.Collections$SynchronizedList.get(Collections.java:537)
       at org.rajawali3d.materials.MaterialManager.taskReload(MaterialManager.java:71)
       at org.rajawali3d.renderer.Renderer.initScene(Renderer.java:367)
       at com.sandro.aerial.RendererActivity.onRenderSurfaceSizeChanged(RendererActivity.java:206)
       at org.rajawali3d.view.SurfaceView$RendererDelegate.onSurfaceChanged(SurfaceView.java:232)
       at android.opengl.GLSurfaceView$GLThread.guardedRun(GLSurfaceView.java:1520)
       at android.opengl.GLSurfaceView$GLThread.run(GLSurfaceView.java:1248)
```

I believe that this PR can fix this issue.