### PR TITLE
UV orientation in ScreenQuad primitive now matches that of Plane.

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/primitives/ScreenQuad.java
+++ b/rajawali/src/main/java/org/rajawali3d/primitives/ScreenQuad.java
@@ -184,10 +184,10 @@ public class ScreenQuad extends Object3D {
 				vertices[vertexCount + 2] = 0;
 
 				if (mCreateTextureCoords) {
-					float u = (float) mSegmentsW - ((float) i / (float) mSegmentsW);
-					textureCoords[texCoordCount++] = (1.0f - u) * mNumTextureTiles;
+					float u = (float) i / (float) mSegmentsW;
+					textureCoords[texCoordCount++] = u * mNumTextureTiles;
 					float v = (float) j / (float) mSegmentsH;
-					textureCoords[texCoordCount++] = v * mNumTextureTiles;
+					textureCoords[texCoordCount++] = (1.0f - v) * mNumTextureTiles;
 				}
 
 				normals[vertexCount] = 0;


### PR DESCRIPTION
fixes Tilted camera images on the ScreenQuad #1850