### PR TITLE
added ScreenMappingRatio setter and getter to ArcballCamera

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/cameras/ArcballCamera.java
+++ b/rajawali/src/main/java/org/rajawali3d/cameras/ArcballCamera.java
@@ -7,6 +7,8 @@ import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 
+import android.support.annotation.FloatRange;
+
 import org.rajawali3d.Object3D;
 import org.rajawali3d.math.MathUtil;
 import org.rajawali3d.math.Matrix4;
@@ -38,7 +40,7 @@ public class ArcballCamera extends Camera {
     private Matrix4 mScratchMatrix;
     private Vector3 mScratchVector;
     private double mStartFOV;
-    private float mScreenMapping = 1;
+    @FloatRange(from = -1, to = 1) private float mScreenMapping = 1;
 
     public ArcballCamera(Context context, View view) {
         this(context, view, null);
@@ -74,12 +76,13 @@ public class ArcballCamera extends Camera {
         super.setProjectionMatrix(width, height);
     }
 
-    public void setScreenMappingRatio(float ratio) {
+    public void setScreenMappingRatio(@FloatRange(from = -1, to = 1) float ratio) {
         if(ratio > 1) ratio = 1;
         if(ratio < -1) ratio = -1;
         mScreenMapping = ratio;
     }
 
+    @FloatRange(from=-1,to=1)
     public float getScreenMappingRatio() {
 	return mScreenMapping;
     }

--- a/rajawali/src/main/java/org/rajawali3d/cameras/ArcballCamera.java
+++ b/rajawali/src/main/java/org/rajawali3d/cameras/ArcballCamera.java
@@ -38,6 +38,7 @@ public class ArcballCamera extends Camera {
     private Matrix4 mScratchMatrix;
     private Vector3 mScratchVector;
     private double mStartFOV;
+    private float mScreenMapping = 1;
 
     public ArcballCamera(Context context, View view) {
         this(context, view, null);
@@ -73,6 +74,16 @@ public class ArcballCamera extends Camera {
         super.setProjectionMatrix(width, height);
     }
 
+    public void setScreenMappingRatio(float ratio) {
+        if(ratio > 1) ratio = 1;
+        if(ratio < -1) ratio = -1;
+        mScreenMapping = ratio;
+    }
+
+    public float getScreenMappingRatio() {
+	return mScreenMapping;
+    }
+
     private void mapToSphere(final float x, final float y, Vector3 out)
     {
         float lengthSquared = x * x + y * y;
@@ -89,8 +100,8 @@ public class ArcballCamera extends Camera {
 
     private void mapToScreen(final float x, final float y, Vector2 out)
     {
-        out.setX((2 * x - mLastWidth) / mLastWidth);
-        out.setY(-(2 * y - mLastHeight) / mLastHeight);
+        out.setX(mScreenMapping * (2 * x - mLastWidth) / mLastWidth);
+        out.setY(-mScreenMapping  * (2 * y - mLastHeight) / mLastHeight);
     }
 
     private void startRotation(final float x, final float y)


### PR DESCRIPTION
responding to #1868 

added `ScreenMappingRatio` setter and getter to `ArcballCamera`, value is 1,
setting this ratio to -1 accomodates the use case of looking at all sides small object
from the outside, without having an environment to give context to the camera movement.
Values from -1 to 1 are accepted, setting to 0 locks the `ArcballCamera` at the current orientation.