### PR TITLE
fix for creating custom shaders issue #1885

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -689,8 +689,8 @@ public class Material {
             if (mVertexShader.needsBuild()) mVertexShader.initialize();
             if (mFragmentShader.needsBuild()) mFragmentShader.initialize();
 
-            if (mVertexShader.needsBuild()) mVertexShader.buildShader();
-            if (mFragmentShader.needsBuild()) mFragmentShader.buildShader();
+            // custom shaders already have a shader string,
+            // so we do not need to build one
         }
 
         if (RajLog.isDebugEnabled()) {

--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -689,8 +689,8 @@ public class Material {
             if (mVertexShader.needsBuild()) mVertexShader.initialize();
             if (mFragmentShader.needsBuild()) mFragmentShader.initialize();
 
-            // custom shaders already have a shader string,
-            // so we do not need to build one
+            if (mVertexShader.needsBuild()) mVertexShader.buildShader();
+            if (mFragmentShader.needsBuild()) mFragmentShader.buildShader();
         }
 
         if (RajLog.isDebugEnabled()) {

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
@@ -629,6 +629,10 @@ public abstract class AShader extends AShaderBase {
 	}
 
 	public void buildShader() {
+		// if shaderstring is already built
+		// we do not need to build it again
+		if(mShaderString != null) return; 
+
 		mShaderSB = new StringBuilder();
 		StringBuilder s = mShaderSB;
 


### PR DESCRIPTION
`Material.createShaders()` is nolonger overwriting custom shader strings