### PR TITLE
added xyzw() and rgba() functions to RVect4, and fixed w() assignment.

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
@@ -507,11 +507,28 @@ public abstract class AShaderBase {
 			super(name, dataType, value);
 		}
 		
-		public ShaderVar w()
+		public ShaderVar wxyz()
 		{
 			ShaderVar v = getReturnTypeForOperation(mDataType, mDataType);
-			v.setName(this.mName + ".w");
+			v.setName(this.mName + ".wxyz");
+			v.mInitialized = true;
 			return v;
+		}
+		
+		public ShaderVar rgba()
+		{
+			ShaderVar v = getReturnTypeForOperation(mDataType, mDataType);
+			v.setName(this.mName + ".rgba");
+			v.mInitialized = true;
+			return v;
+		}
+		
+		public ShaderVar w()
+		{
+                        ShaderVar v = new RFloat();
+                        v.setName(this.mName + ".w");
+                        v.mInitialized = true;
+                        return v;
 		}
 		
 		public ShaderVar a()

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2013 Dennis Ippel
+  Copyright 2013 Dennis Ippel
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -507,10 +507,10 @@ public abstract class AShaderBase {
 			super(name, dataType, value);
 		}
 		
-		public ShaderVar wxyz()
+		public ShaderVar xyzw()
 		{
 			ShaderVar v = getReturnTypeForOperation(mDataType, mDataType);
-			v.setName(this.mName + ".wxyz");
+			v.setName(this.mName + ".xyzw");
 			v.mInitialized = true;
 			return v;
 		}

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
@@ -1,5 +1,5 @@
 /**
-  Copyright 2013 Dennis Ippel
+ * Copyright 2013 Dennis Ippel
  * 
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at


### PR DESCRIPTION
This addresses the issue raised in #1858

None too pleased with the `xyzw` nomenclature, but it seems the way forward, as `RVect4` inherits from `RVect3`