### PR TITLE
Move depth test for color picking to per-object

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -426,7 +426,17 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 				}
 			}
 
-			// Blending and depth testing are set up globally in Scene.doColorPicking()
+			// Blending test is set up globally in Scene.doColorPicking()
+
+			// Depth testing is set-up per-object in order to avoid ScreenQuads to overshadow other
+			// objects, see https://github.com/Rajawali/Rajawali/issues/1634
+			if (!mEnableDepthTest) GLES20.glDisable(GLES20.GL_DEPTH_TEST);
+			else {
+				GLES20.glEnable(GLES20.GL_DEPTH_TEST);
+				GLES20.glDepthFunc(GLES20.GL_LESS);
+			}
+
+			GLES20.glDepthMask(mEnableDepthMask);
 
 			// Material setup is independent of batching, and has no need for
 			// shader params, textures, normals, vertex colors, or current object...

--- a/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
+++ b/rajawali/src/main/java/org/rajawali3d/scene/Scene.java
@@ -1172,12 +1172,6 @@ public class Scene {
 		// Set background color (to Object3D.UNPICKABLE to prevent any conflicts)
 		GLES20.glClearColor(1.0f, 1.0f, 1.0f, 1.0f);
 
-		// Configure depth testing
-		GLES20.glEnable(GLES20.GL_DEPTH_TEST);
-		GLES20.glDepthFunc(GLES20.GL_LESS);
-		GLES20.glDepthMask(true);
-		GLES20.glClearDepthf(1.0f);
-
 		// Clear buffers used for color-picking
 		GLES20.glClear(GLES20.GL_COLOR_BUFFER_BIT | GLES20.GL_DEPTH_BUFFER_BIT);
 


### PR DESCRIPTION
Ref: #1634 

This change allows color picking to work when there is a ScreenQuad involved in the scene, by properly rendering said quad in the background, like it happens with the generated scene.

In order to test this, please use branch `color-picker` in [my fork of the Tango Java samples](https://github.com/adamantivm/tango-examples-java/tree/color-picker). This branch includes modification to its `build.gradle` so that it will use a latest Rajawali 1.1 snapshot, so that it is possible to build the Rajawali fix and test it against this sample.

Please clone my fork, build the app `java_augmented_reality_example` and run it on a Tango-enabled device. You should see a rotating earth with a revolving moon against the backdrop of the live camera image. If you click on the earth, you should see the following in the logcat:

```
05-24 12:32:26.336 10329-10329/com.projecttango.experiments.augmentedrealitysample D/AugmentedRealityRenderer: ---> pick attempt at (1474.0,420.0
05-24 12:32:26.394 10329-10360/com.projecttango.experiments.augmentedrealitysample D/AugmentedRealityRenderer: Picked: org.rajawali3d.primitives.ScreenQuad@648f81d8
```

Before the Rajawali fix, you will always see the `ScreenQuad` being picked. After the fix, the proper sphere for the moon or earth should be picked.

@jwoolston I hope this makes it simple to verify. Please do let me know if anything here is problematic and I'll be happy to work towards making it easier. Thanks again for your support.
