### PR TITLE
addresses issue #1184

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/animation/Animation.java
+++ b/rajawali/src/main/java/org/rajawali3d/animation/Animation.java
@@ -225,6 +225,7 @@ public abstract class Animation extends Playable {
 
 		// Update the elapsed time
 		mElapsedTime += deltaTime;
+                if(mElapsedTime > mDuration) mElapsedTime = mDuration;
 
 		// Calculate the interpolated time
 		final double interpolatedTime = mInterpolator


### PR DESCRIPTION
in Animation.update(), mElapsedtime could be set larger than mDuration,
causing a value greater than one to be sent to the Interpolator.