### PR TITLE
working implementation of ArcballCamera.resetCameraOrientation()

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/cameras/ArcballCamera.java
+++ b/rajawali/src/main/java/org/rajawali3d/cameras/ArcballCamera.java
@@ -167,6 +167,13 @@ public class ArcballCamera extends Camera {
         return m;
     }
 
+    @Override
+    public void resetCameraOrientation() {
+        super.resetCameraOrientation();
+        mEmpty.setOrientation(Quaternion.getIdentity());
+        getViewMatrix();
+    }
+
     public void setFieldOfView(double fieldOfView) {
         synchronized (mFrustumLock) {
             mStartFOV = fieldOfView;


### PR DESCRIPTION
addresses #1572 
provides a working override of `ArcballCamera.resetCameraOrientation()`