### PR TITLE
Store original UV map when first calling Object.setAtlasTile()

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -62,6 +62,7 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
     protected Material mMaterial;
 
     protected Geometry3D     mGeometry;
+    protected FloatBuffer    mOriginalTextureCoords;
     protected Object3D       mParent;
     protected List<Object3D> mChildren;
     protected String         mName;
@@ -937,14 +938,21 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
      * Maps the (x,y) coordinates of <code>tileName</code> in <code>atlas</code>
      * to the TextureCoordinates of this BaseObject3D
      *
+     * Saves a copy of the original TextureCoordinates in case of future mapping.
+     *
      * @param tileName
      * @param atlas
      */
     public void setAtlasTile(String tileName, TextureAtlas atlas) {
         Tile tile = atlas.getTileNamed(tileName);
-        FloatBuffer fb = this.getGeometry().getTextureCoords();
+
+        if(mOriginalTextureCoords == null) {
+            mOriginalTextureCoords = this.getGeometry().getTextureCoords().duplicate();
+        }
+
+        FloatBuffer fb = FloatBuffer.allocate(mOriginalTextureCoords.capacity());
         for (int i = 0; i < fb.capacity(); i++) {
-            double uvIn = fb.get(i);
+            double uvIn = mOriginalTextureCoords.get(i);
             double uvOut;
             if (i % 2 == 0) {
                 uvOut = (uvIn * (tile.width / atlas.getWidth())) + tile.x / atlas.getWidth();


### PR DESCRIPTION
This allow the UV map to be restored on subsequent calls.

adresses #2107