### PR TITLE
implements a simpler approach to lighting Dynamic Materials

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -521,74 +521,78 @@ public class Material {
     protected void createShaders() {
         if (!mIsDirty)
             return;
-        if (mCustomVertexShader == null && mCustomFragmentShader == null) {
-            //
-            // -- Check textures
-            //
 
-            List<ATexture> diffuseTextures = null;
-            List<ATexture> normalMapTextures = null;
-            List<ATexture> envMapTextures = null;
-            List<ATexture> skyTextures = null;
-            List<ATexture> specMapTextures = null;
-            List<ATexture> alphaMapTextures = null;
+        mVertexShader = mCustomVertexShader;
+        mFragmentShader = mCustomFragmentShader;
 
-            boolean hasCubeMaps = false;
-            boolean hasVideoTexture = false;
+        //
+        // -- Check textures
+        //
 
-            for (int i = 0; i < mTextureList.size(); i++) {
-                ATexture texture  = mTextureList.get(i);
+        List<ATexture> diffuseTextures = null;
+        List<ATexture> normalMapTextures = null;
+        List<ATexture> envMapTextures = null;
+        List<ATexture> skyTextures = null;
+        List<ATexture> specMapTextures = null;
+        List<ATexture> alphaMapTextures = null;
 
-                switch (texture.getTextureType()) {
-                    case VIDEO_TEXTURE:
-                        hasVideoTexture = true;
-                        // no break statement, add the video texture to the diffuse textures
-                    case DIFFUSE:
-                    case RENDER_TARGET:
-                        if (diffuseTextures == null) diffuseTextures = new ArrayList<>();
-                        diffuseTextures.add(texture);
-                        break;
-                    case NORMAL:
-                        if (normalMapTextures == null) normalMapTextures = new ArrayList<>();
-                        normalMapTextures.add(texture);
-                        break;
-                    case CUBE_MAP:
-                        hasCubeMaps = true;
-                    case SPHERE_MAP:
-                        boolean isSkyTexture = false;
-                        boolean isEnvironmentTexture = false;
+        boolean hasCubeMaps = false;
+        boolean hasVideoTexture = false;
 
-                        if (texture.getClass() == SphereMapTexture.class) {
-                            isSkyTexture = ((SphereMapTexture) texture).isSkyTexture();
-                            isEnvironmentTexture = ((SphereMapTexture) texture).isEnvironmentTexture();
-                        } else if (texture.getClass() == CubeMapTexture.class) {
-                            isSkyTexture = ((CubeMapTexture) texture).isSkyTexture();
-                            isEnvironmentTexture = ((CubeMapTexture) texture).isEnvironmentTexture();
-                        }
+        for (int i = 0; i < mTextureList.size(); i++) {
+            ATexture texture  = mTextureList.get(i);
 
-                        if (isSkyTexture) {
-                            if (skyTextures == null)
-                                skyTextures = new ArrayList<>();
-                            skyTextures.add(texture);
-                        } else if (isEnvironmentTexture) {
-                            if (envMapTextures == null)
-                                envMapTextures = new ArrayList<>();
-                            envMapTextures.add(texture);
-                        }
-                        break;
-                    case SPECULAR:
-                        if (specMapTextures == null) specMapTextures = new ArrayList<>();
-                        specMapTextures.add(texture);
-                        break;
-                    case ALPHA:
-                        if (alphaMapTextures == null) alphaMapTextures = new ArrayList<>();
-                        alphaMapTextures.add(texture);
-                        break;
-                    default:
-                        break;
-                }
+            switch (texture.getTextureType()) {
+                case VIDEO_TEXTURE:
+                    hasVideoTexture = true;
+                    // no break statement, add the video texture to the diffuse textures
+                case DIFFUSE:
+                case RENDER_TARGET:
+                    if (diffuseTextures == null) diffuseTextures = new ArrayList<>();
+                    diffuseTextures.add(texture);
+                    break;
+                case NORMAL:
+                    if (normalMapTextures == null) normalMapTextures = new ArrayList<>();
+                    normalMapTextures.add(texture);
+                    break;
+                case CUBE_MAP:
+                    hasCubeMaps = true;
+                case SPHERE_MAP:
+                    boolean isSkyTexture = false;
+                    boolean isEnvironmentTexture = false;
+
+                    if (texture.getClass() == SphereMapTexture.class) {
+                        isSkyTexture = ((SphereMapTexture) texture).isSkyTexture();
+                        isEnvironmentTexture = ((SphereMapTexture) texture).isEnvironmentTexture();
+                    } else if (texture.getClass() == CubeMapTexture.class) {
+                        isSkyTexture = ((CubeMapTexture) texture).isSkyTexture();
+                        isEnvironmentTexture = ((CubeMapTexture) texture).isEnvironmentTexture();
+                    }
+
+                    if (isSkyTexture) {
+                        if (skyTextures == null)
+                            skyTextures = new ArrayList<>();
+                        skyTextures.add(texture);
+                    } else if (isEnvironmentTexture) {
+                        if (envMapTextures == null)
+                            envMapTextures = new ArrayList<>();
+                        envMapTextures.add(texture);
+                    }
+                    break;
+                case SPECULAR:
+                    if (specMapTextures == null) specMapTextures = new ArrayList<>();
+                    specMapTextures.add(texture);
+                    break;
+                case ALPHA:
+                    if (alphaMapTextures == null) alphaMapTextures = new ArrayList<>();
+                    alphaMapTextures.add(texture);
+                    break;
+                default:
+                    break;
             }
+        }
 
+        if (mVertexShader == null && mFragmentShader == null) {
             mVertexShader = new VertexShader();
             mVertexShader.enableTime(mTimeEnabled);
             mVertexShader.hasCubeMaps(hasCubeMaps);
@@ -601,102 +605,96 @@ public class Material {
             mFragmentShader.hasCubeMaps(hasCubeMaps);
             onPreFragmentShaderInitialize(mFragmentShader);
             mFragmentShader.initialize();
-
-            if (diffuseTextures != null && diffuseTextures.size() > 0) {
-                DiffuseTextureFragmentShaderFragment fragment = new DiffuseTextureFragmentShaderFragment(diffuseTextures);
-                mFragmentShader.addShaderFragment(fragment);
-            }
-
-            if (normalMapTextures != null && normalMapTextures.size() > 0) {
-                NormalMapFragmentShaderFragment fragment = new NormalMapFragmentShaderFragment(normalMapTextures);
-                mFragmentShader.addShaderFragment(fragment);
-            }
-
-            if (envMapTextures != null && envMapTextures.size() > 0) {
-                EnvironmentMapFragmentShaderFragment fragment = new EnvironmentMapFragmentShaderFragment(envMapTextures);
-                mFragmentShader.addShaderFragment(fragment);
-            }
-
-            if (skyTextures != null && skyTextures.size() > 0) {
-                SkyTextureFragmentShaderFragment fragment = new SkyTextureFragmentShaderFragment(skyTextures);
-                mFragmentShader.addShaderFragment(fragment);
-            }
-
-            if (hasVideoTexture)
-                mFragmentShader.addPreprocessorDirective("#extension GL_OES_EGL_image_external : require");
-
-            checkForPlugins(PluginInsertLocation.PRE_LIGHTING);
-
-            //
-            // -- Lighting
-            //
-
-            if (mLightingEnabled && mLights != null && mLights.size() > 0) {
-                mVertexShader.setLights(mLights);
-                mFragmentShader.setLights(mLights);
-
-                mLightsVertexShaderFragment = new LightsVertexShaderFragment(mLights);
-                mLightsVertexShaderFragment.setAmbientColor(mAmbientColor);
-                mLightsVertexShaderFragment.setAmbientIntensity(mAmbientIntensity);
-                mVertexShader.addShaderFragment(mLightsVertexShaderFragment);
-                mFragmentShader.addShaderFragment(new LightsFragmentShaderFragment(mLights));
-
-                checkForPlugins(PluginInsertLocation.PRE_DIFFUSE);
-
-                //
-                // -- Diffuse method
-                //
-
-                if (mDiffuseMethod != null) {
-                    mDiffuseMethod.setLights(mLights);
-                    IShaderFragment fragment = mDiffuseMethod.getVertexShaderFragment();
-                    if (fragment != null)
-                        mVertexShader.addShaderFragment(fragment);
-                    fragment = mDiffuseMethod.getFragmentShaderFragment();
-                    mFragmentShader.addShaderFragment(fragment);
-                }
-
-                checkForPlugins(PluginInsertLocation.PRE_SPECULAR);
-
-                //
-                // -- Specular method
-                //
-
-                if (mSpecularMethod != null) {
-                    mSpecularMethod.setLights(mLights);
-                    mSpecularMethod.setTextures(specMapTextures);
-                    IShaderFragment fragment = mSpecularMethod.getVertexShaderFragment();
-                    if (fragment != null)
-                        mVertexShader.addShaderFragment(fragment);
-
-                    fragment = mSpecularMethod.getFragmentShaderFragment();
-                    if (fragment != null)
-                        mFragmentShader.addShaderFragment(fragment);
-                }
-            }
-
-            checkForPlugins(PluginInsertLocation.PRE_ALPHA);
-
-            if (alphaMapTextures != null && alphaMapTextures.size() > 0) {
-                AlphaMapFragmentShaderFragment fragment = new AlphaMapFragmentShaderFragment(alphaMapTextures);
-                mFragmentShader.addShaderFragment(fragment);
-            }
-
-            checkForPlugins(PluginInsertLocation.PRE_TRANSFORM);
-            checkForPlugins(PluginInsertLocation.POST_TRANSFORM);
-
-            mVertexShader.buildShader();
-            mFragmentShader.buildShader();
         } else {
-            mVertexShader = mCustomVertexShader;
-            mFragmentShader = mCustomFragmentShader;
-
             if (mVertexShader.needsBuild()) mVertexShader.initialize();
             if (mFragmentShader.needsBuild()) mFragmentShader.initialize();
-
-            if (mVertexShader.needsBuild()) mVertexShader.buildShader();
-            if (mFragmentShader.needsBuild()) mFragmentShader.buildShader();
         }
+
+        if (diffuseTextures != null && diffuseTextures.size() > 0) {
+            DiffuseTextureFragmentShaderFragment fragment = new DiffuseTextureFragmentShaderFragment(diffuseTextures);
+            mFragmentShader.addShaderFragment(fragment);
+        }
+
+        if (normalMapTextures != null && normalMapTextures.size() > 0) {
+            NormalMapFragmentShaderFragment fragment = new NormalMapFragmentShaderFragment(normalMapTextures);
+            mFragmentShader.addShaderFragment(fragment);
+        }
+
+        if (envMapTextures != null && envMapTextures.size() > 0) {
+            EnvironmentMapFragmentShaderFragment fragment = new EnvironmentMapFragmentShaderFragment(envMapTextures);
+            mFragmentShader.addShaderFragment(fragment);
+        }
+
+        if (skyTextures != null && skyTextures.size() > 0) {
+            SkyTextureFragmentShaderFragment fragment = new SkyTextureFragmentShaderFragment(skyTextures);
+            mFragmentShader.addShaderFragment(fragment);
+        }
+
+        if (hasVideoTexture)
+            mFragmentShader.addPreprocessorDirective("#extension GL_OES_EGL_image_external : require");
+
+        checkForPlugins(PluginInsertLocation.PRE_LIGHTING);
+
+        //
+        // -- Lighting
+        //
+
+        if (mLightingEnabled && mLights != null && mLights.size() > 0) {
+            mVertexShader.setLights(mLights);
+            mFragmentShader.setLights(mLights);
+
+            mLightsVertexShaderFragment = new LightsVertexShaderFragment(mLights);
+            mLightsVertexShaderFragment.setAmbientColor(mAmbientColor);
+            mLightsVertexShaderFragment.setAmbientIntensity(mAmbientIntensity);
+            mVertexShader.addShaderFragment(mLightsVertexShaderFragment);
+            mFragmentShader.addShaderFragment(new LightsFragmentShaderFragment(mLights));
+
+            checkForPlugins(PluginInsertLocation.PRE_DIFFUSE);
+
+            //
+            // -- Diffuse method
+            //
+
+            if (mDiffuseMethod != null) {
+                mDiffuseMethod.setLights(mLights);
+                IShaderFragment fragment = mDiffuseMethod.getVertexShaderFragment();
+                if (fragment != null)
+                    mVertexShader.addShaderFragment(fragment);
+                fragment = mDiffuseMethod.getFragmentShaderFragment();
+                mFragmentShader.addShaderFragment(fragment);
+            }
+
+            checkForPlugins(PluginInsertLocation.PRE_SPECULAR);
+
+            //
+            // -- Specular method
+            //
+
+            if (mSpecularMethod != null) {
+                mSpecularMethod.setLights(mLights);
+                mSpecularMethod.setTextures(specMapTextures);
+                IShaderFragment fragment = mSpecularMethod.getVertexShaderFragment();
+                if (fragment != null)
+                    mVertexShader.addShaderFragment(fragment);
+
+                fragment = mSpecularMethod.getFragmentShaderFragment();
+                if (fragment != null)
+                    mFragmentShader.addShaderFragment(fragment);
+            }
+        }
+
+        checkForPlugins(PluginInsertLocation.PRE_ALPHA);
+
+        if (alphaMapTextures != null && alphaMapTextures.size() > 0) {
+            AlphaMapFragmentShaderFragment fragment = new AlphaMapFragmentShaderFragment(alphaMapTextures);
+            mFragmentShader.addShaderFragment(fragment);
+        }
+
+        checkForPlugins(PluginInsertLocation.PRE_TRANSFORM);
+        checkForPlugins(PluginInsertLocation.POST_TRANSFORM);
+
+        if (mVertexShader.needsBuild()) mVertexShader.buildShader();
+        if (mFragmentShader.needsBuild()) mFragmentShader.buildShader();
 
         if (RajLog.isDebugEnabled()) {
             RajLog.d("-=-=-=- VERTEX SHADER -=-=-=-");

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
@@ -605,6 +605,7 @@ public abstract class AShader extends AShaderBase {
 	public void addShaderFragment(IShaderFragment fragment)
 	{
 		if(fragment == null) return;
+		if(mShaderFragments == null) return;
 		mShaderFragments.add(fragment);
 	}
 


### PR DESCRIPTION
Modifies Material.createShaders() to make lighting fragments available to custom shaders if necessary.

addresses #2112

now the code becomes
```
                DirectionalLight key = new DirectionalLight(-3,4,5);
                key.setPower(3.0f);
                getCurrentScene().addLight(key);

                vertexShader = new VertexShader();
                fragmentShader = new DynamicShader();

                material = new Material(vertexShader, fragmentShader);
                material.setColor(Color.MAGENTA);
                material.setColorInfluence(0.5f);
                material.setAmbientColor(Color.CYAN);
                material.setDiffuseMethod(new DiffuseMethod.Lambert());
                material.enableLighting(true);
                material.enableTime(true);

                Object3D obj = new Cube(2);
                obj.setMaterial(material);
                getCurrentScene().addChild(obj);
```