### PR TITLE
Made abstract methods in ATexture protected

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ACompressedTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ACompressedTexture.java
@@ -132,7 +132,7 @@ public abstract class ACompressedTexture extends ATexture {
         return mByteBuffers;
     }
 
-    void add() throws TextureException
+    protected void add() throws TextureException
 	{
 		int[] textures = new int[1];
 		GLES20.glGenTextures(1, textures, 0);
@@ -183,11 +183,11 @@ public abstract class ACompressedTexture extends ATexture {
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 	}
 
-	void remove() {
+	protected void remove() {
 		GLES20.glDeleteTextures(1, new int[] { mTextureId }, 0);
 	}
 
-	void replace() throws TextureException
+	protected void replace() throws TextureException
 	{
 		if (mByteBuffers == null || mByteBuffers.length == 0)
 			throw new TextureException("Texture could not be replaced because there is no ByteBuffer set.");
@@ -207,7 +207,7 @@ public abstract class ACompressedTexture extends ATexture {
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 	}
 
-	void reset() throws TextureException
+	protected void reset() throws TextureException
 	{
 		if (mByteBuffers != null)
 		{

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/AMultiTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/AMultiTexture.java
@@ -123,7 +123,7 @@ public abstract class AMultiTexture extends ATexture {
         mCompressedTextures = compressedTextures;
     }
 	
-	void reset() throws TextureException
+	protected void reset() throws TextureException
 	{
 		if(mBitmaps != null)
 		{

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ASingleTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ASingleTexture.java
@@ -117,7 +117,7 @@ public abstract class ASingleTexture extends ATexture
 		return mByteBuffer;
 	}
 
-	void add() throws TextureException
+	protected void add() throws TextureException
 	{
 		if(mCompressedTexture != null)
 		{
@@ -208,7 +208,7 @@ public abstract class ASingleTexture extends ATexture
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 	}
 
-	void remove() throws TextureException
+	protected void remove() throws TextureException
 	{
 		if(mCompressedTexture != null)
 			mCompressedTexture.remove();
@@ -216,7 +216,7 @@ public abstract class ASingleTexture extends ATexture
 			GLES20.glDeleteTextures(1, new int[] { mTextureId }, 0);
 	}
 
-	void replace() throws TextureException
+	protected void replace() throws TextureException
 	{
 		if(mCompressedTexture != null)
 		{
@@ -254,7 +254,7 @@ public abstract class ASingleTexture extends ATexture
 		GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
 	}
 
-	void reset() throws TextureException
+	protected void reset() throws TextureException
 	{
 		if(mCompressedTexture != null)
 		{

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
@@ -466,13 +466,13 @@ public abstract class ATexture {
         return mCompressedTexture;
     }
 
-    abstract void add() throws TextureException;
+    abstract protected void add() throws TextureException;
 
-    abstract void remove() throws TextureException;
+    abstract protected void remove() throws TextureException;
 
-    abstract void replace() throws TextureException;
+    abstract protected void replace() throws TextureException;
 
-    abstract void reset() throws TextureException;
+    abstract protected void reset() throws TextureException;
 
     public static class TextureException extends Exception {
         private static final long serialVersionUID = -4218033240897223177L;

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/CubeMapTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/CubeMapTexture.java
@@ -152,7 +152,7 @@ public class CubeMapTexture extends AMultiTexture {
     }
 
     @Override
-    void add() throws TextureException {
+    protected void add() throws TextureException {
         if(mHasCompressedTextures) {
             for(int i=0; i<mCompressedTextures.length; i++) {
                 mCompressedTextures[i].add();
@@ -173,7 +173,7 @@ public class CubeMapTexture extends AMultiTexture {
     }
 
     @Override
-    void remove() throws TextureException {
+    protected void remove() throws TextureException {
         if(mHasCompressedTextures) {
             for(int i=0; i<mCompressedTextures.length; i++) {
                 mCompressedTextures[i].remove();
@@ -183,7 +183,7 @@ public class CubeMapTexture extends AMultiTexture {
     }
 
     @Override
-    void replace() throws TextureException {
+    protected void replace() throws TextureException {
         checkBitmapConfiguration();
 
         if (mTextureId > 0) {

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/Etc1Texture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/Etc1Texture.java
@@ -79,7 +79,7 @@ public class Etc1Texture extends ACompressedTexture {
     }
 
     @Override
-    void add() throws TextureException {
+    protected void add() throws TextureException {
         if(mResourceId != -1) {
             Resources resources = TextureManager.getInstance().getContext().getResources();
             try {
@@ -133,7 +133,7 @@ public class Etc1Texture extends ACompressedTexture {
     }
 
     @Override
-    void reset() throws TextureException {
+    protected void reset() throws TextureException {
         super.reset();
         if (mBitmap != null) {
             mBitmap.recycle();

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/Etc2Texture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/Etc2Texture.java
@@ -91,7 +91,7 @@ public class Etc2Texture extends ACompressedTexture {
     }
 
     @Override
-    void add() throws TextureException {
+    protected void add() throws TextureException {
         super.add();
         if (mShouldRecycle) {
             if (mBitmap != null) {
@@ -102,7 +102,7 @@ public class Etc2Texture extends ACompressedTexture {
     }
 
     @Override
-    void reset() throws TextureException {
+    protected void reset() throws TextureException {
         super.reset();
         if (mBitmap != null) {
             mBitmap.recycle();

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/RenderTargetTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/RenderTargetTexture.java
@@ -106,7 +106,7 @@ public class RenderTargetTexture extends ATexture {
         super.setFrom(other);
     }
 
-    @Override void add() throws TextureException {
+    @Override protected void add() throws TextureException {
         if (mWidth == 0 || mHeight == 0) {
             throw new TextureException(
                     "FrameBufferTexture could not be added because the width and/or height weren't specified.");
@@ -161,11 +161,11 @@ public class RenderTargetTexture extends ATexture {
         }
     }
 
-    @Override void remove() {
+    @Override protected void remove() {
         GLES20.glDeleteTextures(1, new int[]{ mTextureId }, 0);
     }
 
-    @Override void replace() {
+    @Override protected void replace() {
         return;
     }
 
@@ -180,7 +180,7 @@ public class RenderTargetTexture extends ATexture {
         GLES20.glBindTexture(GLES20.GL_TEXTURE_2D, 0);
     }
 
-    void reset() {
+    protected void reset() {
         return;
     }
 }

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/StreamingTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/StreamingTexture.java
@@ -63,7 +63,7 @@ public class StreamingTexture extends ATexture {
         return new StreamingTexture(this);
     }
 
-    void add() throws TextureException {
+    protected void add() throws TextureException {
         int[] textures = new int[1];
         GLES20.glGenTextures(1, textures, 0);
         int textureId = textures[0];
@@ -93,16 +93,16 @@ public class StreamingTexture extends ATexture {
         }
     }
 
-    void remove() {
+    protected void remove() {
         GLES20.glDeleteTextures(1, new int[]{mTextureId}, 0);
         mSurfaceTexture.release();
     }
 
-    void replace() {
+    protected void replace() {
         return;
     }
 
-    void reset() {
+    protected void reset() {
         mSurfaceTexture.release();
     }
 


### PR DESCRIPTION
Made `ATexture` methods `add()`, `remove()`, `replace()`, and `reset()` protected instead of package private.

A necessary step in extending the core with animated WebP textures.

However, as such a texture must depend upon an external libWebP library, these are best contained separately from our core, especially as WebP animation support is likely to become builtin to Android in the future.

addresses #2057