### PR TITLE
fix CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 defaults: &defaults
   working_directory: ~/repo
   docker:
-    - image: rajawali/rajawali:release-1.1
+    - image: rajawali/rajawali:1.1
   environment:
     TERM: dumb
 


### PR DESCRIPTION
It's still broken https://circleci.com/gh/Rajawali/Rajawali/109 as I see https://hub.docker.com/r/rajawali/rajawali/tags
you use now only `1.1` instead with leading _release-_ of previous `release-1.0`

Sorry my fault, I didn't double checked it