### PR TITLE
Object3D.getChildByName() now ignores children with no name

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Object3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Object3D.java
@@ -733,8 +733,10 @@ public class Object3D extends ATransformable3D implements Comparable<Object3D>, 
 
     public Object3D getChildByName(String name) {
         for (int i = 0, j = mChildren.size(); i < j; i++) {
-            if (mChildren.get(i).getName().equals(name)) {
-                return mChildren.get(i);
+            Object3D child = mChildren.get(i);
+            if (child.getName() == null) continue;
+            if (child.getName().equals(name)) {
+                return child;
             }
         }
 


### PR DESCRIPTION
Fix for issue #2139 