### PR TITLE
implemented basic dynamic light mapping

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -32,6 +32,7 @@ import org.rajawali3d.materials.shaders.fragments.LightsVertexShaderFragment;
 import org.rajawali3d.materials.shaders.fragments.texture.AlphaMapFragmentShaderFragment;
 import org.rajawali3d.materials.shaders.fragments.texture.DiffuseTextureFragmentShaderFragment;
 import org.rajawali3d.materials.shaders.fragments.texture.EnvironmentMapFragmentShaderFragment;
+import org.rajawali3d.materials.shaders.fragments.texture.LightMapFragmentShaderFragment;
 import org.rajawali3d.materials.shaders.fragments.texture.NormalMapFragmentShaderFragment;
 import org.rajawali3d.materials.shaders.fragments.texture.SkyTextureFragmentShaderFragment;
 import org.rajawali3d.materials.textures.ATexture;
@@ -244,7 +245,7 @@ public class Material {
      */
     protected final float[] mNormalFloats = new float[9];
     /**
-     * Scratch normal amtrix. The normal matrix is used in the shaders to transform
+     * Scratch normal matrix. The normal matrix is used in the shaders to transform
      * the normal into eye space.
      */
     protected Matrix4 mNormalMatrix = new Matrix4();
@@ -530,6 +531,7 @@ public class Material {
         //
 
         List<ATexture> diffuseTextures = null;
+        List<ATexture> lightMapTextures = null;
         List<ATexture> normalMapTextures = null;
         List<ATexture> envMapTextures = null;
         List<ATexture> skyTextures = null;
@@ -550,6 +552,10 @@ public class Material {
                 case RENDER_TARGET:
                     if (diffuseTextures == null) diffuseTextures = new ArrayList<>();
                     diffuseTextures.add(texture);
+                    break;
+                case LIGHT:
+                    if (lightMapTextures == null) lightMapTextures = new ArrayList<>();
+                    lightMapTextures.add(texture);
                     break;
                 case NORMAL:
                     if (normalMapTextures == null) normalMapTextures = new ArrayList<>();
@@ -687,6 +693,11 @@ public class Material {
 
         if (alphaMapTextures != null && alphaMapTextures.size() > 0) {
             AlphaMapFragmentShaderFragment fragment = new AlphaMapFragmentShaderFragment(alphaMapTextures);
+            mFragmentShader.addShaderFragment(fragment);
+        }
+
+        if (lightMapTextures != null && lightMapTextures.size() > 0) {
+            LightMapFragmentShaderFragment fragment = new LightMapFragmentShaderFragment(lightMapTextures);
             mFragmentShader.addShaderFragment(fragment);
         }
 

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/fragments/texture/LightMapFragmentShaderFragment.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/fragments/texture/LightMapFragmentShaderFragment.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.rajawali3d.materials.shaders.fragments.texture;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.rajawali3d.materials.Material.PluginInsertLocation;
+import org.rajawali3d.materials.textures.ATexture;
+import org.rajawali3d.materials.textures.ATexture.TextureType;
+import org.rajawali3d.materials.textures.ATexture.WrapType;
+
+public class LightMapFragmentShaderFragment extends ATextureFragmentShaderFragment {
+	public final static String SHADER_ID = "LIGHT_MAP_FRAGMENT";
+	private ArrayList videoTextureMap = new ArrayList();
+	private ArrayList textureMap = new ArrayList();
+
+	public LightMapFragmentShaderFragment(List<ATexture> textures)
+	{
+		super(textures);
+		for(int i=0; i<mTextures.size(); i++)
+		{
+			ATexture texture = mTextures.get(i);
+			if(texture.getTextureType() == TextureType.VIDEO_TEXTURE)
+				videoTextureMap.add(i);
+			else
+				textureMap.add(i);
+		}
+	}
+	
+	public String getShaderId() {
+		return SHADER_ID;
+	}
+	
+	@Override
+	public void main() {
+		super.main();
+		RVec4 color = (RVec4)getGlobal(DefaultShaderVar.G_COLOR);
+		RVec2 textureCoord = (RVec2)getGlobal(DefaultShaderVar.G_TEXTURE_COORD);
+		RVec4 glowColor = new RVec4("glowColor");
+		
+		for(int i=0; i<mTextures.size(); i++)
+		{
+			ATexture texture = mTextures.get(i);
+			if(texture.offsetEnabled())
+				textureCoord.assignAdd(getGlobal(DefaultShaderVar.U_OFFSET, i));
+			if(texture.getWrapType() == WrapType.REPEAT)
+				textureCoord.assignMultiply(getGlobal(DefaultShaderVar.U_REPEAT, i));
+			
+			if(texture.getTextureType() == TextureType.VIDEO_TEXTURE)
+				glowColor.assign(texture2D(muVideoTextures[videoTextureMap.indexOf(i)], textureCoord));
+			else
+				glowColor.assign(texture2D(muTextures[textureMap.indexOf(i)], textureCoord));
+			glowColor.assignMultiply(muInfluence[i]);
+			color.rgb().assignAdd(glowColor.rgb());
+		}
+	}
+	
+	@Override
+	public PluginInsertLocation getInsertLocation() {
+		return PluginInsertLocation.IGNORE;
+	}
+	
+	public void bindTextures(int nextIndex) {}
+	public void unbindTextures() {}
+}

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
@@ -38,7 +38,8 @@ public abstract class ATexture {
         CUBE_MAP,
         SPHERE_MAP,
         VIDEO_TEXTURE,
-        COMPRESSED
+        COMPRESSED,
+        LIGHT
     }
 
     /**

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/LightMapTexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/LightMapTexture.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * 
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.rajawali3d.materials.textures;
+
+import android.graphics.Bitmap;
+
+public class LightMapTexture extends ASingleTexture {
+	public LightMapTexture(LightMapTexture other)
+	{
+		super(other);
+	}
+	
+	public LightMapTexture(String textureName)
+	{
+		super(TextureType.LIGHT, textureName);
+	}
+	
+	public LightMapTexture(String textureName, int resourceId)
+	{
+		super(TextureType.LIGHT, textureName);
+		setResourceId(resourceId);
+	}
+	
+	public LightMapTexture(String textureName, Bitmap bitmap)
+	{
+		super(TextureType.LIGHT, textureName, bitmap);
+	}
+	
+	public LightMapTexture(String textureName, ACompressedTexture compressedTexture)
+	{
+		super(TextureType.LIGHT, textureName, compressedTexture);
+	}
+	
+	public LightMapTexture clone() {
+		return new LightMapTexture(this);
+	}
+}


### PR DESCRIPTION
addresses issue #2163

lightmaps are added after lighting and only to to the rgb channels,
this approach leaves alpha mapping intact.
![2020-05-03](https://user-images.githubusercontent.com/17471201/80911869-d82a2580-8ced-11ea-86e7-fb191d24bd6c.gif)

an example lightmap rendered in blender
![glow](https://user-images.githubusercontent.com/17471201/80912089-5dfaa080-8cef-11ea-99d4-082b19878cac.png)
