### PR TITLE
implemented PointShell and PointAperatureMaterialPlugin for point sprite effects

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/plugins/PointApertureMaterialPlugin.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/plugins/PointApertureMaterialPlugin.java
@@ -1,0 +1,128 @@
+package org.rajawali3d.materials.plugins;
+
+import org.rajawali3d.materials.Material;
+import org.rajawali3d.materials.plugins.IMaterialPlugin;
+import org.rajawali3d.materials.shaders.AShader;
+import org.rajawali3d.materials.shaders.AShaderBase;
+import org.rajawali3d.materials.shaders.IShaderFragment;
+
+public class PointApertureMaterialPlugin implements IMaterialPlugin {
+    private ApertureVertexShaderFragment mVertexShader;
+    private ApertureFragmentShaderFragment mFragmentShader;
+
+    public PointApertureMaterialPlugin(float aperture)
+    {
+        mVertexShader = new ApertureVertexShaderFragment(aperture);
+        mFragmentShader = new ApertureFragmentShaderFragment();
+    }
+
+    @Override
+    public Material.PluginInsertLocation getInsertLocation() {
+        return Material.PluginInsertLocation.PRE_LIGHTING;
+    }
+
+    @Override
+    public IShaderFragment getVertexShaderFragment() {
+        return mVertexShader;
+    }
+
+    @Override
+    public IShaderFragment getFragmentShaderFragment() {
+        return mFragmentShader;
+    }
+
+
+    @Override
+    public void bindTextures(int nextIndex) {}
+    @Override
+    public void unbindTextures() {}
+
+    private class ApertureVertexShaderFragment extends AShader implements IShaderFragment
+    {
+        public final static String SHADER_ID = "APERTURE_VERTEX_FRAGMENT";
+        float mAperture;
+
+        public ApertureVertexShaderFragment(float aperture)
+        {
+            super(ShaderType.VERTEX_SHADER_FRAGMENT);
+            mAperture = aperture;
+            initialize();
+        }
+
+        @Override
+        public void main() {
+            RVec4 a_position = (RVec4) getGlobal(DefaultShaderVar.A_POSITION);
+            RVec4 g_position = (RVec4) getGlobal(DefaultShaderVar.G_POSITION);
+
+            g_position.assign(a_position);
+            mShaderSB.append("gl_PointSize = " + mAperture + ";\n");
+        }
+
+        @Override
+        public void setLocations(int programHandle) {
+        }
+
+        @Override
+        public void applyParams() {
+            super.applyParams();
+        }
+
+
+        @Override
+        public String getShaderId() {
+            return SHADER_ID;
+        }
+
+        @Override
+        public Material.PluginInsertLocation getInsertLocation() {
+            return Material.PluginInsertLocation.IGNORE;
+        }
+
+        @Override
+        public void bindTextures(int nextIndex) {}
+
+        @Override
+        public void unbindTextures() {}
+    }
+
+    private class ApertureFragmentShaderFragment extends AShader implements IShaderFragment
+    {
+        public final static String SHADER_ID = "APERTURE_FRAGMENT_FRAGMENT";
+
+        public ApertureFragmentShaderFragment()
+        {
+            super(ShaderType.FRAGMENT_SHADER_FRAGMENT);
+            initialize();
+        }
+
+        @Override
+        public String getShaderId() {
+            return SHADER_ID;
+        }
+
+        @Override
+        public void main() {
+            RVec4 v_color = (RVec4) getGlobal(AShaderBase.DefaultShaderVar.V_COLOR);
+            RVec4 g_color = (RVec4) getGlobal(AShaderBase.DefaultShaderVar.G_COLOR);
+
+            RFloat d = new RFloat("d");
+            d.assign(clamp(length(castVec2("gl_PointCoord*2.-1.")), 0,1));
+            d.assign(pow(d,v_color.r()));
+            RVec3 color = new RVec3("color");
+            color.assign(castVec3(d.multiply(-1).add(1)));
+            g_color.assign(v_color.multiply(castVec4(color, 1)));
+        }
+
+        @Override
+        public Material.PluginInsertLocation getInsertLocation() {
+            return Material.PluginInsertLocation.IGNORE;
+        }
+
+        @Override
+        public void bindTextures(int nextIndex) {}
+
+        @Override
+        public void unbindTextures() {}
+    }
+}
+

--- a/rajawali/src/main/java/org/rajawali3d/materials/plugins/PointOrbitalMaterialPlugin.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/plugins/PointOrbitalMaterialPlugin.java
@@ -1,0 +1,162 @@
+package org.rajawali3d.materials.plugins;
+
+import android.opengl.GLES20;
+
+import org.rajawali3d.materials.Material;
+import org.rajawali3d.materials.plugins.IMaterialPlugin;
+import org.rajawali3d.materials.shaders.AShader;
+import org.rajawali3d.materials.shaders.IShaderFragment;
+
+public class PointOrbitalMaterialPlugin implements IMaterialPlugin {
+    private PointOrbitalVertexShaderFragment mVertexShaderFragment;
+
+    public PointOrbitalMaterialPlugin() {
+        this.mVertexShaderFragment = new PointOrbitalVertexShaderFragment(1);
+    }
+
+    public PointOrbitalMaterialPlugin(float speed) {
+        this.mVertexShaderFragment = new PointOrbitalVertexShaderFragment(speed);
+    }
+
+    @Override
+    public Material.PluginInsertLocation getInsertLocation() {
+        return Material.PluginInsertLocation.PRE_LIGHTING;
+    }
+
+    @Override
+    public IShaderFragment getVertexShaderFragment() {
+        return mVertexShaderFragment;
+    }
+
+    @Override
+    public IShaderFragment getFragmentShaderFragment() {
+        return null;
+    }
+
+    @Override
+    public void bindTextures(int i) {
+
+    }
+
+    @Override
+    public void unbindTextures() {
+
+    }
+
+    public void setSpeed(float speed) {
+        mVertexShaderFragment.setSpeed(speed);
+    }
+
+    private class PointOrbitalVertexShaderFragment extends AShader implements IShaderFragment
+    {
+        public final static String SHADER_ID = "ROTATION_VERTEX_FRAGMENT";
+        float mSpeed;
+        RFloat muSpeed;
+        int muSpeedHandle;
+
+        public PointOrbitalVertexShaderFragment(float speed)
+        {
+            super(ShaderType.VERTEX_SHADER_FRAGMENT);
+            mSpeed = speed;
+            initialize();
+        }
+
+        @Override
+        public void initialize() {
+            super.initialize();
+            muSpeed = (RFloat) addUniform("uSpeed", DataType.FLOAT);
+        }
+
+        public void setSpeed(float speed) {
+            mSpeed = speed;
+            applyParams();
+        }
+
+        /*
+         * animates points by reflecting the initial point position by a plane that rotates
+         * through the origin and oriented to the initial position of each point.
+         */
+        @Override
+        public void main() {
+            RFloat u_time = (RFloat) getGlobal(DefaultShaderVar.U_TIME);
+            RVec4 a_position = (RVec4) getGlobal(DefaultShaderVar.A_POSITION);
+            RVec4 g_position = (RVec4) getGlobal(DefaultShaderVar.G_POSITION);
+
+            RFloat p = new RFloat("p");
+            p.assign(a_position.x().divide(length(a_position.xy())));
+            RFloat q = new RFloat("q");
+            q.assign(a_position.y().divide(length(a_position.xy())));
+
+            RMat3 yaw = new RMat3("yaw");
+            yaw.assign("mat3(\n" +
+                    "    q,-p,0,\n" +
+                    "    p,q,0,\n" +
+                    "    0,0,1\n" +
+                    ")");
+
+            RFloat t = new RFloat("t");
+            t.assign(u_time.multiply(muSpeed));
+
+            RMat3 pitch = new RMat3("pitch");
+            pitch.assign("mat3(\n" +
+                    "    cos(t),0,sin(t),\n" +
+                    "    0,1,0,\n" +
+                    "    -sin(t),0,cos(t)\n" +
+                    ")");
+
+            RVec3 n = new RVec3("n");
+            n.assign(0,0,1);
+            n.assignMultiply(pitch);
+            n.assignMultiply(yaw);
+            // pitch before yaw because this is a reflecting normal
+
+            RFloat a = new RFloat("a");
+            a.assign(n.x());
+            RFloat b = new RFloat("b");
+            b.assign(n.y());
+            RFloat c = new RFloat("c");
+            c.assign(n.z());
+
+            RMat4 reflect = new RMat4("reflect");
+            reflect.assign("mat4(\n" +
+                    "    1.0-2.*a*a, -2.*a*b, -2.*a*c, 0,\n" +
+                    "    -2.*a*b, 1.0-2.*b*b, -2.*b*c, 0,\n" +
+                    "    -2.*a*c, -2.*b*c, 1.0-2.*c*c, 0,\n" +
+                    "    0, 0, 0, 1\n" +
+                    ")");
+
+            g_position.assign(a_position.multiply(reflect));
+        }
+
+        @Override
+        public void setLocations(int programHandle) {
+            super.setLocations(programHandle);
+            muSpeedHandle = getUniformLocation(programHandle, "uSpeed");
+        }
+
+        @Override
+        public void applyParams() {
+            super.applyParams();
+            GLES20.glUniform1f(muSpeedHandle, mSpeed);
+        }
+
+
+        @Override
+        public String getShaderId() {
+            return SHADER_ID;
+        }
+
+        @Override
+        public Material.PluginInsertLocation getInsertLocation() {
+            return Material.PluginInsertLocation.IGNORE;
+        }
+
+        @Override
+        public void bindTextures(int nextIndex) {}
+
+        @Override
+        public void unbindTextures() {}
+    }
+
+
+}

--- a/rajawali/src/main/java/org/rajawali3d/primitives/PointShell.java
+++ b/rajawali/src/main/java/org/rajawali3d/primitives/PointShell.java
@@ -20,14 +20,16 @@ public class PointShell extends Object3D {
         super.preRender();
     }
 
-    public void init(int numStars, float radius) {
+    public void init(int numPoints, float radius) {
 
-        float[] vertices = new float[numStars * 3];
-        float[] normals = new float[numStars * 3];
-        int[] indices = new int[numStars * 3];
-        float[] colors = new float[numStars * 4];
+        float[] vertices = new float[numPoints * 3];
+        float[] normals = new float[numPoints * 3];
+        int[] indices = new int[numPoints * 3];
+        float[] colors = new float[numPoints * 4];
+        float[] textureCoords = new float[numPoints * 2];
+        int texel = (int)Math.ceil(Math.sqrt(numPoints));
 
-        for (int i = 0; i < numStars; ++i) {
+        for (int i = 0; i < numPoints; ++i) {
             Vector3 n = new Vector3(Math.random()*2-1, Math.random()*2-1, Math.random()*2-1);
             n.normalize();
 
@@ -52,6 +54,9 @@ public class PointShell extends Object3D {
             colors[i * 4 + 1] = randColor * randColor;
             colors[i * 4 + 2] = randColor * randColor;
             colors[i * 4 + 3] = 1.0f;
+
+            textureCoords[i * 2 + 0] = i%texel;
+            textureCoords[i * 2 + 1] = i/texel;
         }
 
         setData(vertices, normals, null, colors, indices, true);

--- a/rajawali/src/main/java/org/rajawali3d/primitives/PointShell.java
+++ b/rajawali/src/main/java/org/rajawali3d/primitives/PointShell.java
@@ -1,0 +1,59 @@
+package org.rajawali3d.primitives;
+
+import org.rajawali3d.Object3D;
+import org.rajawali3d.math.vector.Vector3;
+
+public class PointShell extends Object3D {
+
+    public PointShell() {
+        super();
+        init(512, 1);
+    }
+
+    public PointShell(int number, float radius) {
+        super();
+        init(number, radius);
+    }
+
+    @Override
+    protected void preRender() {
+        super.preRender();
+    }
+
+    public void init(int numStars, float radius) {
+
+        float[] vertices = new float[numStars * 3];
+        float[] normals = new float[numStars * 3];
+        int[] indices = new int[numStars * 3];
+        float[] colors = new float[numStars * 4];
+
+        for (int i = 0; i < numStars; ++i) {
+            Vector3 n = new Vector3(Math.random()*2-1, Math.random()*2-1, Math.random()*2-1);
+            n.normalize();
+
+            normals[i * 3 + 0] = (float)n.x;
+            normals[i * 3 + 1] = (float)n.y;
+            normals[i * 3 + 2] = (float)n.z;
+
+            Vector3 v = n.clone();
+            v.multiply(radius);
+
+            vertices[i * 3 + 0] = (float)v.x;
+            vertices[i * 3 + 1] = (float)v.y;
+            vertices[i * 3 + 2] = (float)v.z;
+
+            indices[i * 3 + 0] = i;
+            indices[i * 3 + 1] = i;
+            indices[i * 3 + 2] = i;
+
+            float randColor = (float) Math.random();
+
+            colors[i * 4 + 0] = randColor * randColor;
+            colors[i * 4 + 1] = randColor * randColor;
+            colors[i * 4 + 2] = randColor * randColor;
+            colors[i * 4 + 3] = 1.0f;
+        }
+
+        setData(vertices, normals, null, colors, indices, true);
+    }
+}


### PR DESCRIPTION
implemented `PointShell`, a geometry primitive for point sprite effects
implemented `PointAperatureMaterialPlugin`, a material primitive for point sprite effects

addresses issue #2176

![2020-05-11](https://user-images.githubusercontent.com/17471201/81613666-b8e96300-9393-11ea-9e7d-a88aa44236f2.gif)

added `PointOrbitalMaterialPlugin`, a simple vertex fragment, animates points by reflecting the initial point position by a plane that rotates through the origin and independently oriented with the initial position of each point. A starting point for highlighting specific objects.

![2020-05-18](https://user-images.githubusercontent.com/17471201/82308327-7832b080-9976-11ea-9ab8-87cb4bc7e901.gif)
Usage:
```
            bgMaterial = new Material();
            bgMaterial.enableTime(true);
            bgMaterial.useVertexColors(true);
            bgMaterial.addPlugin(new PointApertureMaterialPlugin(8));
            bgMaterial.addPlugin(new PointOrbitalMaterialPlugin());

            Object3D points = new PointShell(1024,2);
            points.setTransparent(true);
            points.setBlendFunc(GLES20.GL_ONE, GLES20.GL_ONE);
            points.setDrawingMode(GLES20.GL_POINTS);
            points.setMaterial(bgMaterial);
            getCurrentScene().addChild(points);
```
