### PR TITLE
method to retrieve the number of scenes associated with a renderer

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
+++ b/rajawali/src/main/java/org/rajawali3d/renderer/Renderer.java
@@ -696,6 +696,16 @@ public abstract class Renderer implements ISurfaceRenderer {
     }
 
     /**
+     * Retrieve the number of {@link Scene} associated with the Renderer.
+     *
+     * @return int the number of Scenes.
+     * @see {@link Renderer#mScenes}
+     */
+    public int getNumScenes() {
+        return mScenes.size();
+    }
+
+    /**
      * Fetches the specified scene.
      *
      * @param scene Index of the {@link Scene} to fetch.


### PR DESCRIPTION
added for use as infrastructure to enable iterating through the scene list.

observed the need while coding a test jig for issue #2179 