### PR TITLE
Fixing a crash and memory issue in RenderToTextureFragment

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/RenderToTextureFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/postprocessing/RenderToTextureFragment.java
@@ -1,7 +1,9 @@
 package org.rajawali3d.examples.examples.postprocessing;
 
 import android.content.Context;
+
 import androidx.annotation.Nullable;
+
 import org.rajawali3d.Object3D;
 import org.rajawali3d.animation.Animation;
 import org.rajawali3d.animation.RotateOnAxisAnimation;
@@ -96,6 +98,7 @@ public class RenderToTextureFragment extends AExampleFragment {
 			mSphere = new Cube(1);
 			mSphere.setMaterial(cubeMaterial);
 			mOtherScene.addChild(mSphere);
+			addScene(mOtherScene);
 
 			Vector3 axis = new Vector3(1, 1, 0);
 			axis.normalize();
@@ -120,6 +123,16 @@ public class RenderToTextureFragment extends AExampleFragment {
 			// -- Other effect passes could be added here
 			//
 
+			//
+			// -- Get the post-processed/offscreen texture and add it to the cube
+			//
+			try {
+				mCurrentTexture = mEffects.getTexture();
+				mSphere.getMaterial().addTexture(mCurrentTexture);
+			} catch (ATexture.TextureException e) {
+				e.printStackTrace();
+			}
+
 			switchScene(mOtherScene);
 		}
 
@@ -129,20 +142,7 @@ public class RenderToTextureFragment extends AExampleFragment {
 			// -- Off screen rendering first. Render to texture.
 			//
 			mEffects.render(elapsedTime, deltaTime);
-			try {
-				if (mCurrentTexture != null)
-					mSphere.getMaterial().removeTexture(mCurrentTexture);
 
-				//
-				// -- Get the latest updated texture from the post
-				//    processing manager
-				//
-
-				mCurrentTexture = mEffects.getTexture();
-				mSphere.getMaterial().addTexture(mCurrentTexture);
-			} catch (ATexture.TextureException e) {
-				e.printStackTrace();
-			}
 			super.onRender(elapsedTime, deltaTime);
 		}
 	}


### PR DESCRIPTION
This PR fixes two issues that existed on the RenderToTextureFragment example:

1. Crash when backgrounding and then coming back into the app as described in #2179.
2. Removing and re-adding the offscreen texture on every call to `onRender()` was a memory leak of sorts - the example's memory consumption would just grow and grow until the app would crash. In most cases it seemed like it was a GL out of memory crash.

With respect to point 1, the necessary change was to "add" the second scene so that the renderer knew about it.

With respect to point 2, the solution was to just add the offscreen texture to the cube in the init block - it turns out you don't need to re-add it every frame. Doing so once is sufficient for it to render the way one would expect.

Interestingly with this PR the issue mentioned in #2182 does manifest, but sure enough, the changes in that PR fix that issue as well :).