### PR TITLE
implemented default CubeMap texture loading

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/Material.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/Material.java
@@ -583,6 +583,9 @@ public class Material {
                         if (envMapTextures == null)
                             envMapTextures = new ArrayList<>();
                         envMapTextures.add(texture);
+                    } else if(hasCubeMaps) {
+                        if (diffuseTextures == null) diffuseTextures = new ArrayList<>();
+                        diffuseTextures.add(texture);
                     }
                     break;
                 case SPECULAR:

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/fragments/texture/DiffuseTextureFragmentShaderFragment.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/fragments/texture/DiffuseTextureFragmentShaderFragment.java
@@ -60,6 +60,8 @@ public class DiffuseTextureFragmentShaderFragment extends ATextureFragmentShader
 			
 			if(texture.getTextureType() == TextureType.VIDEO_TEXTURE)
 				texColor.assign(texture2D(muVideoTextures[videoTextureMap.indexOf(i)], textureCoord));
+			else if(texture.getTextureType() == TextureType.CUBE_MAP)
+				texColor.assign(textureCube(muCubeTextures[textureMap.indexOf(i)], getGlobal(DefaultShaderVar.V_CUBE_TEXTURE_COORD)));
 			else
 				texColor.assign(texture2D(muTextures[textureMap.indexOf(i)], textureCoord));
 			texColor.assignMultiply(muInfluence[i]);


### PR DESCRIPTION
by default, CubeMap textures are now diffuse shaded,
and pixel data is assigned using the textureCube mapping system

Sky and Environmental Texture Mappings remain unchanged.

addresses issue #2185

![2020-05-31](https://user-images.githubusercontent.com/17471201/83345396-7991a080-a2c7-11ea-8353-afdb3eb1f6cf.gif)