### PR TITLE
Check Gradle on each pull request

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -1,5 +1,6 @@
 name: "Validate Gradle Wrapper"
-on: [push]
+
+on: [pull_request]
 
 jobs:
   validation:


### PR DESCRIPTION
I observed in #2207 this Gradle check job doesn't run

<img width="187" alt="image" src="https://user-images.githubusercontent.com/3314607/97630561-1354a980-1a30-11eb-80c7-40a9cf278684.png">

now it does

<img width="242" alt="image" src="https://user-images.githubusercontent.com/3314607/97630580-1a7bb780-1a30-11eb-9856-b5168d8d2e04.png">
