### PR TITLE
Jitpack build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,6 @@ ext {
     minSdk = 15
     targetSdk = 29
     compileSdk = 29
-    versionCode = 1
-    versionName = '1.1'
     wear = "2.5.0"
     wearService = "17.0.0"
 
@@ -35,16 +33,13 @@ ext {
     extJUnitVersion = "1.1.0"
     espresso_core = "3.2.0"
 
-    tagName = System.getenv('CIRCLE_TAG')
-    isTag = tagName != null && !tagName.isEmpty()
-    buildNumber = System.getenv('CIRCLE_BUILD_NUM') ?: "0"
-    isCi = buildNumber != "0"
+    isCi = System.env.CI == "true"
     maxDexHeap = "2g"
 }
 
 subprojects {
     group 'org.rajawali3d'
-    version "1.3.$buildNumber" + (isTag ? "" : "-SNAPSHOT")
+    version = getTag()
 
     repositories {
         google()
@@ -55,4 +50,31 @@ subprojects {
 
 task clean(type: Delete) {
     delete rootProject.buildDir
+}
+
+
+static def getTag() {
+    def tagVersion = "$System.env.VERSION"
+    if (tagVersion == "null") {
+        // with local un-commited changes a -DIRTY is added
+        def processChanges = "git diff-index --name-only HEAD --".execute()
+        def dirty = ""
+        if (!processChanges.text.toString().trim().isEmpty())
+            dirty = "-DIRTY"
+
+        def process = "git describe --tags".execute()
+        tagVersion = process.text.toString().trim() + dirty
+    } else {
+        def tagVersionToken = tagVersion.split("/")
+        if (tagVersionToken.size() > 2)
+            tagVersion = tagVersionToken[2]
+        else
+            tagVersion = tagVersionToken[0]
+    }
+    return tagVersion
+}
+
+static def getGitCommitCount() {
+    def process = "git rev-list HEAD --count".execute()
+    return process.text.toInteger()
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -7,8 +7,8 @@ android {
         applicationId "org.rajawali3d.examples"
         minSdkVersion 16
         targetSdkVersion rootProject.targetSdk
-        versionCode rootProject.versionCode
-        versionName rootProject.versionName
+        versionCode getGitCommitCount()
+        versionName getTag()
     }
 
     compileOptions {

--- a/examples/src/main/AndroidManifest.xml
+++ b/examples/src/main/AndroidManifest.xml
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest package="org.rajawali3d.examples"
           xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          android:versionCode="1"
-          android:versionName="1.0">
+          xmlns:tools="http://schemas.android.com/tools">
 
     <!-- Override the min sdk provided by the wear module -->
     <uses-sdk tools:overrideLibrary="org.rajawali3d.wear"/>

--- a/rajawali/build.gradle
+++ b/rajawali/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion rootProject.targetSdk
-        versionCode rootProject.versionCode
-        versionName rootProject.versionName
+        versionCode getGitCommitCount()
+        versionName getTag()
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/vr/build.gradle
+++ b/vr/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion rootProject.targetSdk
-        versionCode rootProject.versionCode
-        versionName rootProject.versionName
+        versionCode getGitCommitCount()
+        versionName getTag()
     }
 
     compileOptions {

--- a/vuforia/build.gradle
+++ b/vuforia/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 15
         targetSdkVersion rootProject.targetSdk
-        versionCode rootProject.versionCode
-        versionName rootProject.versionName
+        versionCode getGitCommitCount()
+        versionName getTag()
     }
 
     sourceSets.main {

--- a/wear-example/build.gradle
+++ b/wear-example/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "org.rajawali3d.examples"
         minSdkVersion 21
         targetSdkVersion rootProject.targetSdk
-        versionCode rootProject.versionCode
-        versionName rootProject.versionName
+        versionCode getGitCommitCount()
+        versionName getTag()
     }
 
     compileOptions {

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion rootProject.targetSdk
-        versionCode rootProject.versionCode
-        versionName rootProject.versionName
+        versionCode getGitCommitCount()
+        versionName getTag()
     }
 
     compileOptions {


### PR DESCRIPTION
To have a easy-to-use maven, I recommend to use https://jitpack.io

* remove dependency on circleci for proper working version code and name
* change version code and name logic to only depend on git

Now you simply add a tag and you see it here https://jitpack.io/#Rajawali/Rajawali

Ok, current master fails there, but with this pull request it will work. Please see my fork as an example
https://jitpack.io/#hannesa2/rajawali