### PR TITLE
Release on Github

### DIFF
--- a/.github/workflows/Android-CI-release.yml
+++ b/.github/workflows/Android-CI-release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    name: Publish release
+    runs-on: macOS-latest # it has NDK installed
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+      - name: Install JDK ${{ matrix.java_version }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Install Android SDK
+        uses: hannesa2/action-android/install-sdk@0.0.7.5
+      - name: Build project
+        run: ./gradlew clean build
+        env:
+          VERSION: ${{ github.ref }}
+      - run: |
+          assetsAAR=$(find . -name *release.aar | while read -r asset ; do echo "-a $asset" ; done)
+          VERSION=$(echo $VERSION | cut -d'/' -f3)
+          tag_name="${GITHUB_REF##*/}"
+          hub release create ${assetsAAR} -m "$tag_name" "$tag_name"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ github.ref }}


### PR DESCRIPTION
When you tag a new release, now you will see something similar to this
![image](https://user-images.githubusercontent.com/3314607/98070143-d8ec7180-1e60-11eb-9979-ef62c5b98958.png)

Ok, almost nobody needs this aar files, but you could add text to release and if someone only watches release and not all other communication

![image](https://user-images.githubusercontent.com/3314607/98070298-2b2d9280-1e61-11eb-885f-2c2cc1f21955.png)

he is triggered on new releases
