### PR TITLE
cleaning out an unused VertexAnimationObject3D dependency 

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/Geometry3D.java
@@ -14,7 +14,6 @@ package org.rajawali3d;
 
 import android.graphics.Color;
 import android.opengl.GLES20;
-import org.rajawali3d.animation.mesh.VertexAnimationObject3D;
 import org.rajawali3d.bounds.BoundingBox;
 import org.rajawali3d.bounds.BoundingSphere;
 import org.rajawali3d.math.vector.Vector3;


### PR DESCRIPTION
cleaning out an VertexAnimationObject3D dependency that somehow got into Geometry3D