### PR TITLE
added an animator for the exploding plugin, simplifies rapid disassembly

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/animation/ExplodingAnimation3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/animation/ExplodingAnimation3D.java
@@ -1,0 +1,41 @@
+package org.rajawali3d.animation;
+
+import org.rajawali3d.ATransformable3D;
+import org.rajawali3d.Object3D;
+import org.rajawali3d.animation.Animation3D;
+import org.rajawali3d.materials.Material;
+import org.rajawali3d.materials.plugins.ExplodingMaterialPlugin;
+
+public class ExplodingAnimation3D extends Animation3D {
+    final double mDiffFactorValue;
+    final double mFromFactorValue;
+    final double mToFactorValue;
+
+    public ExplodingAnimation3D(double from, double to) {
+        super();
+        mFromFactorValue = from;
+        mToFactorValue = to;
+        mDiffFactorValue = mToFactorValue - mFromFactorValue;
+    }
+
+    @Override
+    public void setTransformable3D(ATransformable3D transformable3D) {
+        super.setTransformable3D(transformable3D);
+        if (!(transformable3D instanceof Object3D)) {
+            throw new RuntimeException(
+                    getClass().getSimpleName() +"requires the passed transformable3D to be an instance of "
+                            + Object3D.class.getSimpleName());
+        }
+    }
+
+    @Override
+    protected void applyTransformation() {
+        Material material = ((Object3D)mTransformable3D).getMaterial();
+        if(material==null) return;
+        ExplodingMaterialPlugin plugin = (ExplodingMaterialPlugin) material.getPlugin(ExplodingMaterialPlugin.class);
+        if(plugin==null) return;
+        double factor = mDiffFactorValue * mInterpolatedTime;
+        plugin.setFactor(factor);
+    }
+}
+

--- a/rajawali/src/main/java/org/rajawali3d/materials/plugins/ExplodingMaterialPlugin.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/plugins/ExplodingMaterialPlugin.java
@@ -36,7 +36,7 @@ public class ExplodingMaterialPlugin implements IMaterialPlugin {
     }
 
     public void setFactor(double factor) {
-        mVertexShader.setFactor((float)factor);
+        mVertexShader.setFactor((float)(factor*factor));
     }
 
     @Override


### PR DESCRIPTION
works like this:
```
        @Override
        protected void initScene() {
            try {
                getCurrentScene().setBackgroundColor(Color.CYAN & Color.DKGRAY);

                DirectionalLight key = new DirectionalLight(-4,-4,-4);
                key.setPower(5/4f);
                getCurrentScene().addLight(key);

                RectangularPrism prism = new RectangularPrism(2,1,1);
                Material material = new Material();
                material.setColor(Color.RED | Color.GRAY);
                material.setDiffuseMethod(new DiffuseMethod.Lambert());
                material.setAmbientColor(Color.CYAN | Color.GRAY);
                material.setAmbientIntensity(1/8f,1/8f,1/8f);
                material.addPlugin(new ExplodingMaterialPlugin());
                material.enableLighting(true);

                Object3D obj = new Cube(4);
                obj.setScale(1/2f);
                obj.setPosition(0,0,0);
                obj.setMaterial(material);
                obj.setDoubleSided(true);
                getCurrentScene().addChild(obj);

                Animation3D anim = new ExplodingAnimation3D(0,3);
                anim.setTransformable3D(obj);
                anim.setDurationDelta(2);
                anim.setInterpolator(new AccelerateDecelerateInterpolator());
                anim.setRepeatMode(Animation.RepeatMode.REVERSE_INFINITE);
                anim.play();
                getCurrentScene().registerAnimation(anim);

                getCurrentCamera().setUpAxis(Vector3.Axis.Z);
                getCurrentCamera().setPosition(-5,-4,3);
                getCurrentCamera().setLookAt(obj.getPosition());
            } catch (Exception e) {
                Log.e(getClass().getSimpleName(), e.getMessage());
            }
        }
```