### PR TITLE
Fix hesitancy at the end of open paths 

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/curves/Path3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/curves/Path3D.java
@@ -48,14 +48,18 @@ public class Path3D implements ICurve3D {
         return x.clone().multiply(1-a).add(y.clone().multiply(a));
     }
 
+    int getNumTransitions() {
+        return mIsClosed ? getNumPoints() : getNumPoints()-1;
+    }
+
     @Override
     public void calculatePoint(Vector3 result, double t) {
         while(t < 0) t+=1;
         while(t > 1) t-=1;
 
-        int prev = (int)Math.floor(t*getNumPoints());
+        int prev = (int)Math.floor(t*getNumTransitions());
         int next = prev+1;
-        double tween = t*getNumPoints()-prev;
+        double tween = t*getNumTransitions()-prev;
         if(next < getNumPoints()) {
             result.setAll(mix(getPoint(prev), getPoint(next), tween));
             mCurrentTangent.subtractAndSet(getPoint(next), getPoint(prev));

--- a/rajawali/src/main/java/org/rajawali3d/curves/Path4D.java
+++ b/rajawali/src/main/java/org/rajawali3d/curves/Path4D.java
@@ -35,13 +35,17 @@ public class Path4D implements ICurve4D {
         return mPoints.get(index);
     }
 
+    int getNumTransitions() {
+        return mIsClosed ? getNumPoints() : getNumPoints()-1;
+    }
+
     public void calculatePoint(Quaternion result, double t) {
         while(t < 0) t+=1;
         while(t > 1) t-=1;
 
-        int prev = (int)Math.floor(t*getNumPoints());
+        int prev = (int)Math.floor(t*getNumTransitions());
         int next = prev+1;
-        double tween = (t*getNumPoints()-prev);
+        double tween = (t*getNumTransitions()-prev);
         if(next < getNumPoints()) {
             result.slerp(getPoint(prev), getPoint(next), tween);
         } else {


### PR DESCRIPTION
Open paths have one less transition that closed paths, this fixes a slight hesitancy at the end of a `Path3D` and `Path4D`. Noticeable only when repeating a path with an animator in repeat mode.