### PR TITLE
implemented a "Kaydara FBX Binary  " file signature check

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/loader/fbx/LoaderFBX.java
+++ b/rajawali/src/main/java/org/rajawali3d/loader/fbx/LoaderFBX.java
@@ -131,6 +131,9 @@ public class LoaderFBX extends AMeshLoader {
 		String line;
 		try {
 			while((line = buffer.readLine()) != null) {
+				if (line.startsWith("Kaydara FBX Binary  ")) {
+					throw new ParsingException("Kaydara FBX Binary file format not supported.");
+				}
 				String repl = line.replaceAll(REGEX_CLEAN, REPLACE_EMPTY);
 				if(repl.length() == 0 || repl.charAt(0) == COMMENT)
 					continue;


### PR DESCRIPTION
currently `LoaderFBX` does not parse binary FBX files, so we issue an error message and bail.
addresses part of  #2303 and #2228
