### PR TITLE
sanitizing texture names

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
@@ -144,7 +144,7 @@ public abstract class ATexture {
     public ATexture(TextureType textureType, @NonNull String textureName) {
         this();
         mTextureType = textureType;
-        mTextureName = textureName;
+        mTextureName = textureName.replaceAll("[^a-zA-Z0-9_]","");
         mMipmap = true;
         mShouldRecycle = false;
         mWrapType = WrapType.REPEAT;

--- a/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/textures/ATexture.java
@@ -144,7 +144,7 @@ public abstract class ATexture {
     public ATexture(TextureType textureType, @NonNull String textureName) {
         this();
         mTextureType = textureType;
-        mTextureName = textureName.replaceAll("[^a-zA-Z0-9_]","");
+        mTextureName = textureName.replaceAll("[^\\w]","");
         mMipmap = true;
         mShouldRecycle = false;
         mWrapType = WrapType.REPEAT;


### PR DESCRIPTION
allowed texture characters are constrained to [a-zA-Z0-9_]

addresses issue #2326