### PR TITLE
Less dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,11 +15,6 @@ buildscript {
     }
 }
 
-plugins {
-    // ./gradlew dependencyUpdates
-    id 'com.github.ben-manes.versions' version '0.39.0'
-}
-
 ext {
     minSdk = 15
     targetSdk = 30


### PR DESCRIPTION
The less dependencies, the less problems !

`com.github.ben-manes.versions` is not needed at all, because this repo uses `dependabot`

See https://github.com/Rajawali/Rajawali/issues/2372