### PR TITLE
fixed Matrix.multiplyMV

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/math/Matrix.java
+++ b/rajawali/src/main/java/org/rajawali3d/math/Matrix.java
@@ -148,12 +148,13 @@ public class Matrix {
        // matrix-vector multiplication (y = A * x)
         int m = 4;
         int n = 4;
+	Arrays.fill(resultVec,resultVecOffset,resultVecOffset+m,0);
         double[] y = resultVec;
-        double[] a = Arrays.copyOfRange(lhsMat, lhsMatOffset, 16);
-        double[] x = Arrays.copyOfRange(rhsVec, rhsVecOffset, 16);
+        double[] a = Arrays.copyOfRange(lhsMat, lhsMatOffset, lhsMatOffset+16);
+        double[] x = Arrays.copyOfRange(rhsVec, rhsVecOffset, rhsVecOffset+4);
         for (int i = 0; i < m; i++)
             for (int j = 0; j < n; j++)
-                y[i*n+j+resultVecOffset] += a[i*n+j] * x[j];
+                y[i+resultVecOffset] += a[j*n+i] * x[j];
     }
 
     /**

--- a/rajawali/src/test/java/org/rajawali3d/math/MatrixTest.java
+++ b/rajawali/src/test/java/org/rajawali3d/math/MatrixTest.java
@@ -21,18 +21,58 @@ public class MatrixTest {
     };
 
     @Test
-    public void testMultiplyMM() {
+    public void testMultiplyMMidentity() {
         double result[] = new double[16];
         Matrix.multiplyMM(result,0,identity,0,identity,0);
         assertTrue(Arrays.equals(identity, result));
     }
 
     @Test
+    public void testMultiplyMM() {
+	double[] left = new double[]{
+		1, 2, 3, 4,
+		5, 6, 7, 8,
+		9, 10, 11, 12,
+		13, 14, 15, 16
+	};
+	double[] right = new double[]{
+		16, 15, 14, 13,
+		12, 11, 10, 9,
+		8, 7, 6, 5,
+		4, 3, 2, 1
+	};
+	double[] expected = new double[]{
+		386, 444, 502, 560,
+		274, 316, 358, 400,
+		162, 188, 214, 240,
+		50, 60, 70, 80,
+	};
+	double[] result = new double[16];
+	Matrix.multiplyMM(result, 0, left, 0, right, 0);
+        assertTrue(Arrays.equals(expected, result));
+    }
+
+    @Test
+    public void multiplyMVidentity() throws Exception {
+	double[] result = new double[4];
+	double[] vector = new double[]{1, 2, 3, 4};
+	Matrix.multiplyMV(result, 0, identity, 0, vector, 0);
+        assertTrue(Arrays.equals(vector, result));
+    }
+
+    @Test
     public void testMultiplyMV() {
-        double vector[] = { 1,1,1,1 };
-        double result[] = new double[16];
-        Matrix.multiplyMV(result,0,identity,0,vector,0);
-        assertTrue(Arrays.equals(identity, result));
+	double[] matrix = new double[]{
+		2, 0, 0, 0,
+		0, 4, 0, 0,
+		0, 0, 6, 0,
+		1, 2, 3, 1
+	};
+	double[] vector = new double[]{5, 7, 9, 1};
+	double[] expected = new double[]{11, 30, 57, 1};
+	double[] result = new double[4];
+	Matrix.multiplyMV(result, 0, matrix, 0, vector, 0);
+        assertTrue(Arrays.equals(expected, result));
     }
 
     @Test


### PR DESCRIPTION
caused TouchAndDragFragment.moveSelectedObject() to throw OutOfBoundsException

partial fix for #2328