### PR TITLE
Nolonger need to setRotY(180) textured planes

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/materials/AnimatedGIFTextureFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/materials/AnimatedGIFTextureFragment.java
@@ -32,7 +32,6 @@ public class AnimatedGIFTextureFragment extends AExampleFragment {
 			final Material material = new Material();
 			final Plane plane = new Plane(1, 1, 1, 1);
 			plane.setMaterial(material);
-			plane.setRotY(180);
 			getCurrentScene().addChild(plane);
 
 			try {


### PR DESCRIPTION
this bug was likely manifest as a side effect of the #1306 fix.

partially addresses #2328