### PR TITLE
CoalesceAnimation3D now updates ATransformable3D correctly

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/examples/animation/CoalesceAnimationFragment.java
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/animation/CoalesceAnimationFragment.java
@@ -2,6 +2,8 @@ package org.rajawali3d.examples.examples.animation;
 
 import android.content.Context;
 import androidx.annotation.Nullable;
+
+import android.graphics.Color;
 import android.view.animation.LinearInterpolator;
 import org.rajawali3d.animation.Animation;
 import org.rajawali3d.animation.CoalesceAnimation3D;
@@ -47,13 +49,13 @@ public class CoalesceAnimationFragment extends AExampleFragment {
             material.enableLighting(true);
             material.setDiffuseMethod(new DiffuseMethod.Lambert());
             rootObject.setMaterial(material);
-            rootObject.setColor(0xff00ff00);
+            rootObject.setColor(Color.GREEN);
             orbit1.setMaterial(material);
-            orbit1.setColor(0xffffff00);
+            orbit1.setColor(Color.YELLOW);
             orbit2.setMaterial(material);
-            orbit2.setColor(0xff00ffff);
+            orbit2.setColor(Color.CYAN);
             orbit3.setMaterial(material);
-            orbit3.setColor(0xff0000ff);
+            orbit3.setColor(Color.BLUE);
 
             // Add the objects to the scene
             getCurrentScene().addChild(rootObject);

--- a/rajawali/src/main/java/org/rajawali3d/animation/CoalesceAnimation3D.java
+++ b/rajawali/src/main/java/org/rajawali3d/animation/CoalesceAnimation3D.java
@@ -84,7 +84,7 @@ public class CoalesceAnimation3D extends Animation3D {
                     // Calculate the next point
                     config.spiral.calculatePoint(config.object.getPosition(), theta);
                     // Add the coalesce point to translate our spiral
-                    config.object.getPosition().add(config.coalesceAroundPoint);
+                    config.object.setPosition(config.object.getPosition().add(config.coalesceAroundPoint));
                 }
             }
         }


### PR DESCRIPTION
`CoalesceAnimation3D` now requests a model matrix recalculation after modifying `ATransformable3D` position.

addresses part of #2328