### PR TITLE
Cleaned up NumberFormatException 

### DIFF
--- a/examples/src/main/java/org/rajawali3d/examples/Preferences.java
+++ b/examples/src/main/java/org/rajawali3d/examples/Preferences.java
@@ -6,6 +6,8 @@ import android.content.SharedPreferences.OnSharedPreferenceChangeListener;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
 
+import org.rajawali3d.util.RajLog;
+
 /**
  * @author Jared Woolston (jwoolston@keywcorp.com)
  */
@@ -17,7 +19,7 @@ public class Preferences implements OnSharedPreferenceChangeListener {
 
     private final SharedPreferences preferences;
 
-    private String wallpaperRendererPreference;
+    private int wallpaperRendererPreference;
 
     public static Preferences getInstance(@NonNull Context context) {
         if (instance == null) {
@@ -38,7 +40,12 @@ public class Preferences implements OnSharedPreferenceChangeListener {
     }
 
     private void updatePreferences() {
-        wallpaperRendererPreference = preferences.getString(WALLPAPER_RENDERER_KEY, "");
+        try {
+            wallpaperRendererPreference = Integer.parseInt(preferences.getString(WALLPAPER_RENDERER_KEY, "0"));
+        } catch (Exception e) {
+            RajLog.e("updatePreferences() failed: " + e.getMessage());
+            wallpaperRendererPreference = 0;
+        }
     }
 
     @Override
@@ -48,7 +55,7 @@ public class Preferences implements OnSharedPreferenceChangeListener {
     }
 
     @NonNull
-    public String getWallpaperRendererPreference() {
+    public int getWallpaperRendererPreference() {
         return wallpaperRendererPreference;
     }
 }

--- a/examples/src/main/java/org/rajawali3d/examples/wallpaper/RajawaliExampleWallpaper.java
+++ b/examples/src/main/java/org/rajawali3d/examples/wallpaper/RajawaliExampleWallpaper.java
@@ -25,10 +25,8 @@ public class RajawaliExampleWallpaper extends Wallpaper {
     @Override
     public Engine onCreateEngine() {
         RajLog.v("Creating wallpaper engine.");
-        final int renderer = Integer.parseInt(Preferences.getInstance(this).getWallpaperRendererPreference());
-            RajLog.i("Creating wallpaper engine: " + renderer);
-            // TODO: I'm sure there is a better way to do this
-            switch (renderer) {
+        final Preferences preferences = Preferences.getInstance(this);
+            switch (preferences.getWallpaperRendererPreference()) {
                 case 0:
                     mRenderer = new BasicRenderer(this, null);
                     break;
@@ -59,6 +57,7 @@ public class RajawaliExampleWallpaper extends Wallpaper {
                 default:
                     mRenderer = new WallpaperRenderer(this);
             }
+        RajLog.i("Creating wallpaper engine: " + mRenderer.getClass().getSimpleName());
         return new WallpaperEngine(getBaseContext(), mRenderer,
                                    ISurface.ANTI_ALIASING_CONFIG.NONE);
     }


### PR DESCRIPTION
Now catching `NumberFormatException` that was thrown in `RajawaliExampleWallpaper.onCreateEngine()` when parsing fails, defaults to `BasicRenderer`. Moved Integer parsing to `Preferences.updatePreferences()` to make cause and effect more obvious.

addresses wallpaper exception part of #2328