### PR TITLE
corrects `MaskPass` initialization

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/MaskPass.java
+++ b/rajawali/src/main/java/org/rajawali3d/postprocessing/passes/MaskPass.java
@@ -76,11 +76,12 @@ public class MaskPass extends APass {
 		GLES20.glEnable(GLES20.GL_STENCIL_TEST);
 		GLES20.glStencilOp(GLES20.GL_REPLACE, GLES20.GL_REPLACE, GLES20.GL_REPLACE);
 		GLES20.glStencilFunc(GLES20.GL_ALWAYS, writeValue, 0xffffffff);
+		GLES20.glStencilMask (0xFF);
 		GLES20.glClearStencil(clearValue);
+		GLES20.glClear(GLES20.GL_STENCIL_BUFFER_BIT);
 
 		// Draw into the stencil buffer.
-		mScene.render(elapsedTime, deltaTime, readBuffer);
-		mScene.render(elapsedTime, deltaTime, writeBuffer);
+		mScene.render(elapsedTime,deltaTime,null);
 
 		// Re-enable color and depth.
 		GLES20.glColorMask(true, true, true, true);


### PR DESCRIPTION
Now updating the stencil buffer as expected

addresses issue #2427

![2022-01-21](https://user-images.githubusercontent.com/17471201/150608476-d0ed1214-7e17-4d1b-a59b-f83a0bc4bf37.png)
