### PR TITLE
cleaned up `VertexShader` dependencies

### DIFF
--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShader.java
@@ -1290,6 +1290,23 @@ public abstract class AShader extends AShaderBase {
 		return v;
 	}
 
+	public ShaderVar castFloat(float value)
+	{
+		return castFloat(Float.toString(value));
+	}
+
+	public ShaderVar castFloat(ShaderVar value)
+	{
+		return castFloat(value.getVarName());
+	}
+
+	public ShaderVar castFloat(String value)
+	{
+		ShaderVar v = new ShaderVar("float(" + value + ")", DataType.INT);
+		v.mInitialized = true;
+		return v;
+	}
+
 	public ShaderVar castVec2(float x)
 	{
 		return castVec2(Float.toString(x));

--- a/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
+++ b/rajawali/src/main/java/org/rajawali3d/materials/shaders/AShaderBase.java
@@ -1246,6 +1246,36 @@ public abstract class AShaderBase {
 			mShaderSB.append(mName).append(" *= ").append(value).append(";\n");
 		}
 
+		/**
+		 * Assigns and Divides a value to a shader variable. Equivalent to GLSL's '/=' operator.
+		 *
+		 * @param value
+		 */
+		public void assignDivide(ShaderVar value)
+		{
+			assignDivide(value.getName());
+		}
+
+		/**
+		 * Assigns and Divides a value to a shader variable. Equivalent to GLSL's '/=' operator.
+		 *
+		 * @param value
+		 */
+		public void assignDivide(float value)
+		{
+			assignDivide(Float.toString(value));
+		}
+
+		/**
+		 * Assigns and Divides a value to a shader variable. Equivalent to GLSL's '/=' operator.
+		 *
+		 * @param value
+		 */
+		public void assignDivide(String value)
+		{
+			mShaderSB.append(mName).append(" /= ").append(value).append(";\n");
+		}
+
 		protected void writeAssign(String value)
 		{
 			if(!mIsGlobal && !mInitialized)


### PR DESCRIPTION
addresses issue #2429

added helper functions `castFloat` and `assignDivide` to allow the shader definition to be mostly interpreted through `ShaderBase`