### PR TITLE
Revert "Change from Kotlin extensions to ViewBinding"

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
 
 android {
     compileSdkVersion rootProject.compileSdk
@@ -13,10 +14,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments useTestStorageService: 'true'
-    }
-
-    buildFeatures {
-        viewBinding true
     }
 
     buildTypes {

--- a/examples/src/main/java/org/rajawali3d/examples/examples/interactive/ObjectRotateFragment.kt
+++ b/examples/src/main/java/org/rajawali3d/examples/examples/interactive/ObjectRotateFragment.kt
@@ -9,9 +9,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.SeekBar
 import com.bmwgroup.apinext.facedetection.utils.round
+import kotlinx.android.synthetic.main.object_roate_overlay.*
 import org.rajawali3d.Object3D
 import org.rajawali3d.examples.R
-import org.rajawali3d.examples.databinding.ObjectRoateOverlayBinding
 import org.rajawali3d.examples.examples.AExampleFragment
 import org.rajawali3d.lights.DirectionalLight
 import org.rajawali3d.loader.LoaderAWD
@@ -25,50 +25,42 @@ import org.rajawali3d.util.ObjectColorPicker
 class ObjectRotateFragment : AExampleFragment() {
 
     private var dataRenderer: ObjectRotateRenderer? = null
-    private var _binding: ObjectRoateOverlayBinding? = null
-    private val binding get() = _binding!!
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         super.onCreateView(inflater, container, savedInstanceState)
-        _binding = ObjectRoateOverlayBinding.inflate(inflater, container, false)
-        val view = binding.root
-        return view
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        _binding = null
+        inflater.inflate(R.layout.object_roate_overlay, mLayout, true)
+        return mLayout
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
-        binding.textMixed.setOnClickListener { binding.seekBarMixed.progress = 0 }
-        binding.textY.setOnClickListener { binding.seekBarY.progress = 0 }
-        binding.textHorizontal.setOnClickListener { binding.seekBarHoizontal.progress = 0 }
+        textMixed.setOnClickListener { seekBarMixed.progress = 0 }
+        textY.setOnClickListener { seekBarY.progress = 0 }
+        textHorizontal.setOnClickListener { seekBarHoizontal.progress = 0 }
 
-        binding.seekBarMixed.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+        seekBarMixed.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                 dataRenderer?.rotateDataX(progress.toDouble())
-                binding.textMixed.text = "Z=${progress}"
+                textMixed.text = "Z=${progress}"
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
             override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
         })
-        binding.seekBarY.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+        seekBarY.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                 dataRenderer?.rotateDataY(progress.toDouble())
-                binding.textY.text = "Y=${progress}"
+                textY.text = "Y=${progress}"
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit
             override fun onStopTrackingTouch(seekBar: SeekBar) = Unit
         })
-        binding.seekBarHoizontal.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
+        seekBarHoizontal.setOnSeekBarChangeListener(object : SeekBar.OnSeekBarChangeListener {
             override fun onProgressChanged(seekBar: SeekBar, progress: Int, fromUser: Boolean) {
                 dataRenderer?.rotateDataZ(progress.toDouble())
-                binding.textHorizontal.text = "X=${progress}"
+                textHorizontal.text = "X=${progress}"
             }
 
             override fun onStartTrackingTouch(seekBar: SeekBar) = Unit

--- a/wear-example/build.gradle
+++ b/wear-example/build.gradle
@@ -10,9 +10,7 @@ android {
         versionCode getGitCommitCount()
         versionName getTag()
     }
-    buildFeatures {
-        viewBinding true
-    }
+    
     buildTypes {
         release {
             minifyEnabled false


### PR DESCRIPTION
This reverts commit 67a1b2d511fcf84839463f7a393f9a49a14c5cd1.

Sorry, the view binding prevents a rendering. I don't know why, so I revert it